### PR TITLE
fixes #27: SEL should attempt to parse the first Visible sheet instea…

### DIFF
--- a/R/fileRead.R
+++ b/R/fileRead.R
@@ -25,7 +25,7 @@ readExcelOrCsv <- function(filePath, sheet = 1, header = FALSE) {
   if (grepl("\\.xlsx?$",filePath)) {
     tryCatch({
       wb <- XLConnect::loadWorkbook(filePath)
-      sheetToRead <- which(!unlist(lapply(XLConnect::getSheets(wb), XLConnect::isSheetHidden, object = wb)))[sheet]
+      sheetToRead <- which(unlist(lapply(XLConnect::getSheets(wb), XLConnect::isSheetVisible, object = wb)))[sheet]
       output <- XLConnect::readWorksheet(wb, sheet = sheetToRead, header = header, dateTimeFormat="%Y-%m-%d")
     }, error = function(e) {
       stopUser("Cannot read input excel file")


### PR DESCRIPTION
…d of the first non-hidden sheet

Excel has various categories for hidden (Hidden Vs. Very Hidden). Currently we don't detect "Very Hidden" and this breaks the parser. We should instead detect the first "Visible" sheet which is a category we can key off of more reliably.