### PR TITLE
Parsing CSVs with non uniform commas gives erroneous errors

### DIFF
--- a/R/fileRead.R
+++ b/R/fileRead.R
@@ -32,15 +32,15 @@ readDelim <- function(filePath, delim=",", testNLines = 500, ...) {
     #   $        // Till the end  (This is necessary, else every comma will satisfy the condition)
     # )
     splitRegex <- paste0(delim,"(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)")
-    if(testNLines > 0) {
-        if(length(fileData) >= testNLines) {
-            fileData <- fileData[1:testNLines]
-        }
+    if(testNLines > 0 && length(fileData) >= testNLines) {
+       linesToTestForNumColumns <- fileData[1:testNLines]
+    } else {
+        linesToTestForNumColumns <- fileData
     }
     # Loop through the lines, split using the regex, count the number of columns, return the max number of columns
-    nCol <- max(unlist(lapply(fileData, function(x) length(tstrsplit(x, split=splitRegex, perl = TRUE)))))
+    nCol <- max(unlist(lapply(linesToTestForNumColumns, function(x) length(tstrsplit(x, split=splitRegex, perl = TRUE)))))
     # Use read.csv, specify the number of columns by passing in a list of column names using the default naming convention of V+{colIndex}
-    output <- read.delim(filePath, sep = delim, na.strings = "", stringsAsFactors=FALSE, fileEncoding=fileEncoding, col.names=paste0("V", 1:nCol), ...)
+    output <- read.delim(text = fileData, sep = delim, na.strings = "", stringsAsFactors=FALSE, fileEncoding=fileEncoding, col.names=paste0("V", 1:nCol), ...)
     return(output)
 }
 

--- a/R/fileRead.R
+++ b/R/fileRead.R
@@ -13,7 +13,7 @@
 #' In fileRead.R
 #' Hidden sheets in xls and xlsx files are ignored.
 
-readDelim <- function(filePath, delim=",", ...) {
+readDelim <- function(filePath, delim=",", testNLines = 500, ...) {
     # Read in a delimited file
     # Use delim regex to count number of columns as read.delim only reads the first 5 rows.
     fileEncoding <- getFileEncoding(filePath)
@@ -32,6 +32,11 @@ readDelim <- function(filePath, delim=",", ...) {
     #   $        // Till the end  (This is necessary, else every comma will satisfy the condition)
     # )
     splitRegex <- paste0(delim,"(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)")
+    if(testNLines > 0) {
+        if(length(fileData) >= testNLines) {
+            fileData <- fileData[1:testNLines]
+        }
+    }
     # Loop through the lines, split using the regex, count the number of columns, return the max number of columns
     nCol <- max(unlist(lapply(fileData, function(x) length(tstrsplit(x, split=splitRegex, perl = TRUE)))))
     # Use read.csv, specify the number of columns by passing in a list of column names using the default naming convention of V+{colIndex}

--- a/R/fileRead.R
+++ b/R/fileRead.R
@@ -13,6 +13,15 @@
 #' In fileRead.R
 #' Hidden sheets in xls and xlsx files are ignored.
 
+readDelim <- function(filePath, delim=",", ...) {
+      fileEncoding <- getFileEncoding(filePath)
+      fileData <- readLines(filePath, encoding=fileEncoding)
+      orig <- '(,)(?=(?:[^"]|"[^"]*")*$)'
+      nCol <- max(unlist(lapply(fileData, function(x) length(tstrsplit(x, split=paste0("(",delim,")(?=(?:[^\"]|\"[^\"]*\")*$)"), perl = TRUE)))))
+      output <- read.delim(filePath, sep = delim, na.strings = "", stringsAsFactors=FALSE, fileEncoding=fileEncoding, col.names=paste0("V", 1:nCol), ...)
+      return(output)
+}
+
 readExcelOrCsv <- function(filePath, sheet = 1, header = FALSE) {
   
   if (is.na(filePath)) {
@@ -32,15 +41,13 @@ readExcelOrCsv <- function(filePath, sheet = 1, header = FALSE) {
     })
   } else if (grepl("\\.csv$",filePath)){
     tryCatch({
-      fileEncoding <- getFileEncoding(filePath)
-      output <- read.csv(filePath, header = header, na.strings = "", stringsAsFactors=FALSE, fileEncoding=fileEncoding)
+      output <- readDelim(filePath, delim = ",", header = header)
     }, error = function(e) {
       stopUser("Cannot read input csv file")
     })
   } else if (grepl("\\.txt$",filePath)){
     tryCatch({
-      fileEncoding <- getFileEncoding(filePath)
-      output <- read.delim(filePath, header = header, na.strings = "", stringsAsFactors=FALSE, fileEncoding=fileEncoding)
+      output <- readDelim(filePath, delim = "\t")
     }, error = function(e) {
       stopUser("Cannot read input txt file")
     })


### PR DESCRIPTION
## Description
 - We are using [read.csv](https://stat.ethz.ch/R-manual/R-devel/library/utils/html/read.table.html) to experiment loader read csv files
The function states:
> The number of data columns is determined by looking at the first five lines of input (or the whole input if it has less than five lines), or from the length of col.names if it is specified and is longer. This could conceivably be wrong if fill or blank.lines.skip are true, so specify col.names if necessary (as in the ‘Examples’).

For csv files which have more columns past 5 lines than in the first 5 lines, to continue using this function, it's required then that we provide a list of col.names to the function so that the function can use the length of the list to read the proper number of columns.

This change reads the file and determines the number of columns by splitting the `first 500 lines` using `scan`.  scan is the underlying function that read.csv, read.delim and other R file reader functions use.  By using scan, we essentially can control the number of lines we are reading while testing for the number of columns in the file.

Additionally, while testing I found that a single quote within the file breaks the read.csv function from parsing the file properly.  I added a code block to detect the warning given by read.csv and turn this into and error. Previously the code would continued on and thrown a non-sensical error.

We added a number of tests to acasclient around csv and text files as well as the tests below done manually:
https://github.com/mcneilco/acasclient/pull/47

## Related Issue
Fixes #64

## How Has This Been Tested?
 - Verified Excel data returned normally just by running and excel file through data loader

**Verified that speed was no impacted in a significant way**

R code test (racas::readExcelOrCsv being original read, and readExcelOrCsv being new sourced code):
```
> system.time(oldData <- racas::readExcelOrCsv("./50k.csv"))
   user  system elapsed 
  0.031   0.000   0.031 
> system.time(newData <- readExcelOrCsv("./50k.csv"))
   user  system elapsed 
  0.059   0.000   0.059 
> identical(newData,oldData)
[1] TRUE
```

**Verified that uniform csv files return identically by running**

With `uniform-quoted-text.csv` data:
```
Experiment Meta Data,,,
Format,Generic,,
Protocol Name,BLAH,,
Experiment Name,BLAH,,
Scientist,Test,,
Notebook,BLAH,,
Page,,,
Assay Date,2022-03-30,,
Project,BLAH,,
,,,
,,,
Calculated Results,,,
Datatype,Number,Number,Number
Corporate Batch ID,t1/2 (min),In vitro Clint (uL/min/mg protein),Clint (mL/min/kg)
TEST-0000979-002,4.36,159.04,"answer in a string,388.06"
TEST-0000148-002,3.31,209.43,511.02
```

R code test (racas::readExcelOrCsv being original read, and readExcelOrCsv being new sourced code):

```R
origData <- racas::readExcelOrCsv("./uniform-quoted-text.csv")
newData <- readExcelOrCsv("./uniform-quoted-text.csv")
identical(origData, newData)
> TRUE
```

**Verified non-uniform csv files get properly read**

With `non-uniform-quoted-text.csv` data:
```
Experiment Meta Data
Format,Generic
Protocol Name,BLAH
Experiment Name,BLAH
Scientist,Test
Notebook,BLAH
Page,,
Assay Date,2022-03-30
Project,BLAH
,
,
Calculated Results,
Datatype,Number,Number,Number
Corporate Batch ID,t1/2 (min),In vitro Clint (uL/min/mg protein),Clint (mL/min/kg)
"TEST-0000979-002",4.36,159.04,"answer in a string,388.06"
TEST-0000148-002,3.31,2"09.43",511.02
```


```R
origData <- racas::readExcelOrCsv("./non-uniform-quoted-text.csv")
newData <- readExcelOrCsv("./non-uniform-quoted-text.csv")
identical(origData, newData)
> FALSE
ncol(origData)
> 2

ncol(newData)
>4
```

print(origData)

```
                                   V1                        V2
1                Experiment Meta Data                      <NA>
2                              Format                   Generic
3                       Protocol Name                      BLAH
4                     Experiment Name                      BLAH
5                           Scientist                      Test
6                            Notebook                      BLAH
7                                Page                      <NA>
8                          Assay Date                2022-03-30
9                             Project                      BLAH
10                               <NA>                      <NA>
11                               <NA>                      <NA>
12                 Calculated Results                      <NA>
13                           Datatype                    Number
14                             Number                    Number
15                 Corporate Batch ID                t1/2 (min)
16 In vitro Clint (uL/min/mg protein)         Clint (mL/min/kg)
17                   TEST-0000979-002                      4.36
18                             159.04 answer in a string,388.06
19                   TEST-0000148-002                      3.31
20                             209.43                    511.02
```

print(newData)
```
                     V1         V2                                 V3                        V4
1  Experiment Meta Data       <NA>                               <NA>                      <NA>
2                Format    Generic                               <NA>                      <NA>
3         Protocol Name       BLAH                               <NA>                      <NA>
4       Experiment Name       BLAH                               <NA>                      <NA>
5             Scientist       Test                               <NA>                      <NA>
6              Notebook       BLAH                               <NA>                      <NA>
7                  Page       <NA>                               <NA>                      <NA>
8            Assay Date 2022-03-30                               <NA>                      <NA>
9               Project       BLAH                               <NA>                      <NA>
10                 <NA>       <NA>                               <NA>                      <NA>
11                 <NA>       <NA>                               <NA>                      <NA>
12   Calculated Results       <NA>                               <NA>                      <NA>
13             Datatype     Number                             Number                    Number
14   Corporate Batch ID t1/2 (min) In vitro Clint (uL/min/mg protein)         Clint (mL/min/kg)
15     TEST-0000979-002       4.36                             159.04 answer in a string,388.06
16     TEST-0000148-002       3.31                             209.43                    511.02
```
