### PR TITLE
ACAS-280: Fix missing units on Dose Response plot axes

### DIFF
--- a/R/rendering.R
+++ b/R/rendering.R
@@ -346,6 +346,22 @@ plotCurve <- function(curveData, params, outFile = NA, ymin = NA, logDose = FALS
     }
   }
   curveLwd <- as.numeric(curveLwd)
+
+  # Set the x and y labels from the first row of data if they aren't already set
+  if(is.na(xlabel)) {
+    doseKind <- ifelse(is.null(curveData$doseKind[1]) || is.na(curveData$doseKind[1]),'Dose',as.character(curveData$doseKind[1]))
+    doseUnits <- ifelse(is.null(curveData$doseUnits[1]) || is.na(curveData$doseUnits[1]),'',paste0(" (",as.character(curveData$doseUnits[1]),")"))
+    xlabel <- paste0(doseKind, doseUnits)
+  }
+  if(is.na(ylabel)) {
+    respKind <- ifelse(is.null(curveData$responseKind[1]) || is.na(curveData$responseKind[1]),'Response',as.character(curveData$responseKind[1]))
+    respUnits <- ifelse(is.null(curveData$responseUnits[1]) || is.na(curveData$responseUnits[1]),'',paste0(" (",as.character(curveData$responseUnits[1]),")"))
+    # Hack to work around the fact we replace "Response" -> "efficacy" when saving dose response data
+    if(respKind == "efficacy") {
+      respKind <- "Response"
+    }
+    ylabel <- paste0(respKind, respUnits)
+  }
   
   # Determine if overlay
   overlay <- FALSE
@@ -684,12 +700,6 @@ plotCurve <- function(curveData, params, outFile = NA, ymin = NA, logDose = FALS
         lines(xlin, lty = 2, lwd = 2.0*scaleFactor,col= col)
     }
     if(labelAxes) {
-      if(is.na(xlabel)) {
-        xlabel <- paste0(ifelse(is.null(curveData$doseKind[1]) || is.na(curveData$doseKind[1]),'Dose',as.character(curveData$doseKind[1])), ifelse(is.null(curveData$doseUnits[1]) || is.na(curveData$doseUnits[1]),'',paste0(" (",as.character(curveData$doseUnits[1]),")")))
-      }
-      if(is.na(ylabel)) {
-        ylabel <- paste0(ifelse(is.null(curveData$responseKind[1]) || is.na(curveData$responseKind[1]),'Response',as.character(curveData$responseKind[1])), ifelse(is.null(curveData$responseUnits[1]) || is.na(curveData$responseUnits[1]),'',paste0(" (",as.character(curveData$responseUnits[1]),")")))
-      }
       title(xlab = xlabel, ylab = ylabel)
     }
   }, error = plotError)


### PR DESCRIPTION
## Description
There was a logical bug preventing units from getting drawn by default on Dose Response plots, even though ACAS had the information stored.
- Fixed main issue by shifting logic up within the function before the expected variable gets changed
- This revealed a secondary issue that a file uploaded with "Response (efficacy)" will be rendered as "efficacy (efficacy)" due to some historical hardcoded switching of responseKind. Undoing that is a complicated fix, so I put in a quick hardcoded line to reverse that, resulting in the expected "Response (efficacy)" label.

## Related Issue

## How Has This Been Tested?
Tested dose response uploads locally and confirmed default curve rendering without overridden options yields sensible labeled curves.
http://localhost:3000/api/curve/render/dr/?legend=false&curveIds=AG-00000052_43
![ACAS-280_AG-00000052_43](https://user-images.githubusercontent.com/18313455/168932138-ee75658e-8fe0-428d-a3a1-8157a8924828.png)


Tested with "Fluorescence (RFU)" instead of "Response (efficacy)" and confirmed nonstandard responseKind is respected.
http://localhost:3000/api/curve/render/dr/?legend=false&curveIds=AG-00000072_45
![ACAS-280_AG-00000072_45](https://user-images.githubusercontent.com/18313455/168932132-8e062f34-86d3-4976-94f7-3cec66958242.png)

