### PR TITLE
Modify log dose 0 points to one log lower than lowest concentration when log scale

### DIFF
--- a/R/rendering.R
+++ b/R/rendering.R
@@ -409,8 +409,9 @@ plotCurve <- function(curveData, params, outFile = NA, ymin = NA, logDose = FALS
     curveData$pch <- params$pch[match(curveData$curveId,params$curveId)]
   }
   
-  #Doses at 0 don't really make sense (and won't work) so this function moves 0 doses down one more dose (calculated by using the next two doses)
-  #If the function can't 
+  # If we are plotting in log space then we need to make sure that log dose are not 0
+  # If modZero is passed in as TRUE then we will make sure all 0 doses are scaled back
+  # one log back from the lowest non-zero dose
   if(modZero && drawPoints) {
     curveData <- modify_or_remove_zero_dose_points(curveData, logDose)
   }

--- a/R/rendering.R
+++ b/R/rendering.R
@@ -716,12 +716,15 @@ modify_or_remove_zero_dose_points <- function(points, logDose) {
         doses <- unique(dose)
         if(length(doses) > 2) {
           values <- unique(doses)[2:3]
+          # If we are doing log dose, then we need to take the log of the values to determine their difference in log space
           if(logDose) {
             answer <- 10^(log10(values[1]) - (log10(values[2])-log10(values[1])))
           } else {
             answer <- values[1] - (values[2] - values[1])
           }
         } else {
+          # If we have only 1 dose (not including 0) then just return 0
+          # because we can't calculate the difference
           answer <- 0
         }
         answer


### PR DESCRIPTION
## Description
ACAS accepts log dose 0 despite it not being able to plot log(0) (infinity).  ACAS handles this during curve rendering by calculating the difference bet ween the next to doses and then plotting the log dose = 0 points at the lowest non-zero concentration minus this difference (essentially plotting the 0s one dose back from the lowest concentration tested).
An update to the data.table R package switched a warning to an error.  
warning in 1.13.4.23:

```
Warning message:
In `[.data.table`(points, dose == 0, `:=`(dose, rep(points[, { :
  Supplied 8 items to be assigned to 2 items of column 'dose' (6 unused)
```
error in 1.13.7.4:
```
Error in `[.data.table`(points, dose == 0, `:=`(dose, rep(points[, { : 
  Supplied 8 items to be assigned to 2 items of column 'dose'. If you wish to 'recycle' the RHS please use rep() to make this intent clear to readers of your code.
```

## Related Issue
ACAS-295

## How Has This Been Tested?
Rendered curve which has 0 as dose and plotted on log x scale.