### PR TITLE
Fix message when excel file cannot be read

### DIFF
--- a/R/fileRead.R
+++ b/R/fileRead.R
@@ -46,7 +46,7 @@ readExcelOrCsv <- function(filePath, sheet = 1, header = FALSE) {
       sheetToRead <- which(unlist(lapply(XLConnect::getSheets(wb), XLConnect::isSheetVisible, object = wb)))[sheet]
       return(XLConnect::readWorksheet(wb, sheet = sheetToRead, header = header, dateTimeFormat="%Y-%m-%d"))
     }, error = function(e) {
-      stopUser("Cannot read input excel file: ", e$message)
+      stopUser(paste0("Cannot read input excel file: ", e$message))
     })
   } else {
     # Get delim


### PR DESCRIPTION
## Description
ACAS displays: 

```
unused argument (e$message)
```

When it cannot read an excel file

## Related Issue
ACAS-312

## How Has This Been Tested?
Ran a file through Experiment Loader which could not be read to reproduce the error.
Ran the code again with this fix and the correct error was displayed.

```
Cannot read input excel file: OldExcelFormatException (Java): The supplied spreadsheet seems to be Excel 5.0/7.0 (BIFF5) format. POI only supports BIFF8 format (from Excel versions 97/2000/XP/2003)
```