### PR TITLE
ACAS-330: replace "viewer" links with a placeholder div

### DIFF
--- a/R/createHtmlSummary.R
+++ b/R/createHtmlSummary.R
@@ -40,9 +40,8 @@ createHtmlSummary <- function(hasError,errorList,hasWarning,warningList,summaryI
   }
   emailViewerLink <- paste0(ifelse(useSSL, "https://", "http://"), applicationSettings$client.host, ":", applicationSettings$client.port, summaryInfo$viewerLink)
   if(!is.null(summaryInfo$viewerLink)) {
-    htmlOutputFormat <- paste0(htmlOutputFormat,"<%=paste0('<a href=\"', summaryInfo$viewerLink, '\" target=\"_blank\" class=\"btn\">Open ", racas::applicationSettings$client.service.result.viewer.displayName, " Report*</a>
-<a href=\"mailto:?subject=", racas::applicationSettings$client.service.result.viewer.displayName, " Live Report for ', summaryInfo$info[racas::applicationSettings$client.protocol.label], ': ', summaryInfo$info[racas::applicationSettings$client.experiment.label] , '&body=Click the following link to run Live Report: ', URLencode(emailViewerLink, reserved = TRUE), '\" class=\"btn\">Email Link to ", racas::applicationSettings$client.service.result.viewer.displayName, " Report</a>
-<p>*Note: there may be a delay before data is visible in ", racas::applicationSettings$client.service.result.viewer.displayName, "</p>')%>")
+    htmlOutputFormat <- paste0(htmlOutputFormat,"<div class=\"bv_openExptInQueryToolSection\"></div>",
+"<p>*Note: there may be a delay before data is visible in ", racas::applicationSettings$client.service.result.viewer.displayName, "</p>")
   }
   
   # Create a header based on whether this is a dryRun and if there are warnings and errors


### PR DESCRIPTION
## Description
The overall case ACAS-330 is about porting the enhanced "Open In" button UX over to the SEL summary. The bulk of the work for this is over on the acas repo.
This racas change is just about simplifying the HTML summary that we insert our controller into.

## Related Issue

## How Has This Been Tested?
Played around with SEL and Experiment Browser in local dev environment, confirmed buttons worked and styling was reasonable.