### PR TITLE
ACAS-367: Fix mangling of JSON strings in clobValues

### DIFF
--- a/R/fileRead.R
+++ b/R/fileRead.R
@@ -13,19 +13,13 @@
 #' In fileRead.R
 #' Hidden sheets in xls and xlsx files are ignored.
 
-readDelim <- function(filePath, delim=",", testNLines = 500, ...) {
+readDelim <- function(filePath, delim=",", ...) {
     # Read in a delimited file
     # Use delim regex to count number of columns as read.delim only reads the first 5 rows.
     fileEncoding <- getFileEncoding(filePath)
     fileData <- readLines(filePath, encoding=fileEncoding)
-    if(testNLines > 0 && length(fileData) >= testNLines) {
-       linesToTestForNumColumns <- fileData[1:testNLines]
-    } else {
-        linesToTestForNumColumns <- fileData
-    }
-    # Loop through the number of test lines and scan for columns
-    # Scan is the underlying function under read.delim.  This is essentially allows us to extend the number of lines used to test for the number of columns because read.delim does not allow us to specify the number of lines to scan.
-    nCol <- max(unlist(lapply(linesToTestForNumColumns, function(x) length(scan(text=x, sep=delim, na.strings = "", quote =  "\"", fileEncoding=fileEncoding, quiet=TRUE, what="character")))))
+    # Scan for the number of columns
+    nCol <- max(count.fields(filePath))
     # Use read.csv, specify the number of columns by passing in a list of column names using the default naming convention of V+{colIndex}
     output <- read.delim(text = fileData, sep = delim, na.strings = "", stringsAsFactors=FALSE, fileEncoding=fileEncoding, col.names=paste0("V", 1:nCol), ...)
     return(output)

--- a/R/tsvSave.R
+++ b/R/tsvSave.R
@@ -174,7 +174,7 @@ formatEntityAsTsvAndUpload <- function(entityData) {
   csvFile <- tempfile(pattern = "csvUpload", tmpdir = "", fileext = ".tsv")
   csvLocalLocation <- paste0(tempdir(), csvFile)
   
-  write.table(entityDataFormatted, file = csvLocalLocation, sep="\t", na = "", row.names = FALSE)
+  write.table(entityDataFormatted, file = csvLocalLocation, sep="\t", na = "", row.names = FALSE, qmethod = "double")
   
   tryCatch({
     response <- rjson::fromJSON(postForm(paste0(racas::applicationSettings$server.service.persistence.fileUrl), 


### PR DESCRIPTION
## Description
Original issue is that valid JSON in an SEL file (as a clobValue) gets mangled, with `"` replaced by `\`, so it is unreadable.
Discovered the cause of that was the "supercsv" library that Roo uses to read analysis group TSVs expects escaped quotes as `""` but R writes them as `\"` by default. Fixed this issue with the first commit, adding `qmethod = "double"` when we write out the CSV that Roo will then read.

In testing this I produced an xls and a csv file, both using Excel. Interestingly, the xls file seems to have `\"` escaped quotes, while the csv has `""` escaped quotes. Our SEL code was unable to read the csv file, failing in `fileRead.R` when we `scan` the file to get `nCol`. I switched the implementation here to `max(count.fields(filePath))`, which does fix the scanning issue, but I'm not sure about performance on large SEL uploads, so this change may be risky.

## Related Issue

## How Has This Been Tested?
Local acasclient tests. See PR: https://github.com/mcneilco/acasclient/pull/77