### PR TITLE
Don't select ignored values when generating entity sql queries in R

### DIFF
--- a/R/entityDefinitions.R
+++ b/R/entityDefinitions.R
@@ -119,7 +119,16 @@ query_definition_list_to_sql <- function(queryDefinitionList, dbType = NA) {
   }
   
   valueJoins <- lapply(values, function(x) {
-    joins <- paste0("LEFT OUTER JOIN analysis_group_value ",gsub(" ","_",x$name)," \nON ",gsub(" ","_",x$parentName),".id = ",gsub(" ","_",x$name),".analysis_state_id \n","AND (",gsub(" ","_",x$name),".ls_kind='",x$ls_kind,"')")
+    alias <- gsub(" ","_",x$name)
+    joins <- paste0(
+      "LEFT OUTER JOIN analysis_group_value ", alias," \nON ",
+      gsub(" ","_",x$parentName),".id = ", alias, ".analysis_state_id \n",
+      "AND (", 
+        alias,".ls_kind='", x$ls_kind,
+        "' AND ",
+        alias,".ignored=", sqliz(getLogicalValue(FALSE)),
+      ")"
+    )
     return(joins)
   })
   valueJoins <- paste0(valueJoins,collapse = " \n")


### PR DESCRIPTION
## Description
R generates queries for dose response curve parameters (not the underlying subject values) using a json structured "entity definition"
The sql generations was not ignoring analysis group values which have been ignored.  Typically this is because we don't ignore values we typically just ignore states, experiments and analysis groups.  However recently we started ignoring "batch code" values when reparenting lots.  This update fixes the sql generated by R to ignore all values which have been ignored

## Related Issue
ACAS-402

## How Has This Been Tested?
Ran queries before and after the change and verified that the returned rows were not duplicated.

Here is a diff of the sql generated with new on the left and original on the right:

<img width="1673" alt="Screen Shot 2022-08-12 at 2 10 01 PM" src="https://user-images.githubusercontent.com/868119/184418712-3d8ad523-2f29-4f15-adaa-bbeb97911088.png">

Full new generated query:
```
SELECT ag.code_name AS "analysisGroupCode",
ag.id AS "analysisGroupId",
ags1.id AS "analysisStateId_1",
curveId.string_value AS "curveId",
curveId.recorded_by AS "recordedBy",
curveId.recorded_date AS "recordedDate",
curveId.ls_transaction AS "lsTransaction",
curveName.string_value AS "curveName",
category.string_value AS "category",
renderingHint.string_value AS "renderingHint",
COALESCE(min.numeric_value::text,min.numeric_value::text) AS "min",
min.unit_kind AS "minUnits",
min.uncertainty AS "minUncertainty",
min.uncertainty_type AS "minUncertaintyType",
min.operator_kind AS "minOperatorKind",
COALESCE(max.numeric_value::text,max.numeric_value::text) AS "max",
max.unit_kind AS "maxUnits",
max.uncertainty AS "maxUncertainty",
max.uncertainty_type AS "maxUncertaintyType",
max.operator_kind AS "maxOperatorKind",
COALESCE(ec50.numeric_value::text,ec50.numeric_value::text) AS "ec50",
ec50.unit_kind AS "ec50Units",
ec50.uncertainty AS "ec50Uncertainty",
ec50.uncertainty_type AS "ec50UncertaintyType",
ec50.operator_kind AS "ec50OperatorKind",
COALESCE(slope.numeric_value::text,slope.numeric_value::text) AS "slope",
slope.unit_kind AS "slopeUnits",
slope.uncertainty AS "slopeUncertainty",
slope.uncertainty_type AS "slopeUncertaintyType",
slope.operator_kind AS "slopeOperatorKind",
fittedMin.numeric_value AS "fittedMin",
fittedMin.unit_kind AS "fittedMinUnits",
fittedMin.uncertainty AS "fittedMinUncertainty",
fittedMin.uncertainty_type AS "fittedMinUncertaintyType",
fittedMax.numeric_value AS "fittedMax",
fittedMax.unit_kind AS "fittedMaxUnits",
fittedMax.uncertainty AS "fittedMaxUncertainty",
fittedMax.uncertainty_type AS "fittedMaxUncertaintyType",
fittedEC50.numeric_value AS "fittedEC50",
fittedEC50.unit_kind AS "fittedEC50Units",
fittedEC50.uncertainty AS "fittedEC50Uncertainty",
fittedEC50.uncertainty_type AS "fittedEC50UncertaintyType",
fittedSlope.numeric_value AS "fittedSlope",
fittedSlope.uncertainty AS "fittedSlopeUncertainty",
fittedSlope.uncertainty_type AS "fittedSlopeUncertaintyType",
sse.numeric_value AS "sse",
sst.numeric_value AS "sst",
rsquared.numeric_value AS "rSquared",
curveErrorsClob.clob_value AS "curveErrorsClob",
reportedValuesClob.clob_value AS "reportedValuesClob",
parameterStdErrorsClob.clob_value AS "parameterStdErrorsClob",
fitSettings.clob_value AS "fitSettings",
fitSummaryClob.clob_value AS "fitSummaryClob",
userFlagStatus.code_value AS "userFlagStatus",
algorithmFlagStatus.code_value AS "algorithmFlagStatus",
batchCode.code_value AS "batchCode"
FROM 
analysis_group ag
LEFT OUTER JOIN analysis_group_state ags1 
ON ag.id = ags1.analysis_group_id 
AND (ags1.ls_kind='dose response' AND ags1.ls_type='data')
LEFT OUTER JOIN analysis_group_value curveId 
ON ags1.id = curveId.analysis_state_id 
AND (curveId.ls_kind='curve id' AND curveId.ignored='0') 
LEFT OUTER JOIN analysis_group_value curveName 
ON ags1.id = curveName.analysis_state_id 
AND (curveName.ls_kind='curve name' AND curveName.ignored='0') 
LEFT OUTER JOIN analysis_group_value category 
ON ags1.id = category.analysis_state_id 
AND (category.ls_kind='category' AND category.ignored='0') 
LEFT OUTER JOIN analysis_group_value renderingHint 
ON ags1.id = renderingHint.analysis_state_id 
AND (renderingHint.ls_kind='Rendering Hint' AND renderingHint.ignored='0') 
LEFT OUTER JOIN analysis_group_value min 
ON ags1.id = min.analysis_state_id 
AND (min.ls_kind='Min' AND min.ignored='0') 
LEFT OUTER JOIN analysis_group_value max 
ON ags1.id = max.analysis_state_id 
AND (max.ls_kind='Max' AND max.ignored='0') 
LEFT OUTER JOIN analysis_group_value ec50 
ON ags1.id = ec50.analysis_state_id 
AND (ec50.ls_kind='EC50' AND ec50.ignored='0') 
LEFT OUTER JOIN analysis_group_value slope 
ON ags1.id = slope.analysis_state_id 
AND (slope.ls_kind='Slope' AND slope.ignored='0') 
LEFT OUTER JOIN analysis_group_value fittedMin 
ON ags1.id = fittedMin.analysis_state_id 
AND (fittedMin.ls_kind='Fitted Min' AND fittedMin.ignored='0') 
LEFT OUTER JOIN analysis_group_value fittedMax 
ON ags1.id = fittedMax.analysis_state_id 
AND (fittedMax.ls_kind='Fitted Max' AND fittedMax.ignored='0') 
LEFT OUTER JOIN analysis_group_value fittedEC50 
ON ags1.id = fittedEC50.analysis_state_id 
AND (fittedEC50.ls_kind='Fitted EC50' AND fittedEC50.ignored='0') 
LEFT OUTER JOIN analysis_group_value fittedSlope 
ON ags1.id = fittedSlope.analysis_state_id 
AND (fittedSlope.ls_kind='Fitted Slope' AND fittedSlope.ignored='0') 
LEFT OUTER JOIN analysis_group_value sse 
ON ags1.id = sse.analysis_state_id 
AND (sse.ls_kind='SSE' AND sse.ignored='0') 
LEFT OUTER JOIN analysis_group_value sst 
ON ags1.id = sst.analysis_state_id 
AND (sst.ls_kind='SST' AND sst.ignored='0') 
LEFT OUTER JOIN analysis_group_value rsquared 
ON ags1.id = rsquared.analysis_state_id 
AND (rsquared.ls_kind='rSquared' AND rsquared.ignored='0') 
LEFT OUTER JOIN analysis_group_value curveErrorsClob 
ON ags1.id = curveErrorsClob.analysis_state_id 
AND (curveErrorsClob.ls_kind='curveErrorsClob' AND curveErrorsClob.ignored='0') 
LEFT OUTER JOIN analysis_group_value reportedValuesClob 
ON ags1.id = reportedValuesClob.analysis_state_id 
AND (reportedValuesClob.ls_kind='reportedValuesClob' AND reportedValuesClob.ignored='0') 
LEFT OUTER JOIN analysis_group_value parameterStdErrorsClob 
ON ags1.id = parameterStdErrorsClob.analysis_state_id 
AND (parameterStdErrorsClob.ls_kind='parameterStdErrorsClob' AND parameterStdErrorsClob.ignored='0') 
LEFT OUTER JOIN analysis_group_value fitSettings 
ON ags1.id = fitSettings.analysis_state_id 
AND (fitSettings.ls_kind='fitSettings' AND fitSettings.ignored='0') 
LEFT OUTER JOIN analysis_group_value fitSummaryClob 
ON ags1.id = fitSummaryClob.analysis_state_id 
AND (fitSummaryClob.ls_kind='fitSummaryClob' AND fitSummaryClob.ignored='0') 
LEFT OUTER JOIN analysis_group_value userFlagStatus 
ON ags1.id = userFlagStatus.analysis_state_id 
AND (userFlagStatus.ls_kind='user flag status' AND userFlagStatus.ignored='0') 
LEFT OUTER JOIN analysis_group_value algorithmFlagStatus 
ON ags1.id = algorithmFlagStatus.analysis_state_id 
AND (algorithmFlagStatus.ls_kind='algorithm flag status' AND algorithmFlagStatus.ignored='0') 
LEFT OUTER JOIN analysis_group_value batchCode 
ON ags1.id = batchCode.analysis_state_id 
AND (batchCode.ls_kind='batch code' AND batchCode.ignored='0') 
WHERE ag.ignored='0' and 
ags1.ignored='0' and 
curveId.string_value in (REPLACEME)
```


Full original generated query:

```
SELECT ag.code_name AS "analysisGroupCode",
ag.id AS "analysisGroupId",
ags1.id AS "analysisStateId_1",
curveId.string_value AS "curveId",
curveId.recorded_by AS "recordedBy",
curveId.recorded_date AS "recordedDate",
curveId.ls_transaction AS "lsTransaction",
curveName.string_value AS "curveName",
category.string_value AS "category",
renderingHint.string_value AS "renderingHint",
COALESCE(min.numeric_value::text,min.numeric_value::text) AS "min",
min.unit_kind AS "minUnits",
min.uncertainty AS "minUncertainty",
min.uncertainty_type AS "minUncertaintyType",
min.operator_kind AS "minOperatorKind",
COALESCE(max.numeric_value::text,max.numeric_value::text) AS "max",
max.unit_kind AS "maxUnits",
max.uncertainty AS "maxUncertainty",
max.uncertainty_type AS "maxUncertaintyType",
max.operator_kind AS "maxOperatorKind",
COALESCE(ec50.numeric_value::text,ec50.numeric_value::text) AS "ec50",
ec50.unit_kind AS "ec50Units",
ec50.uncertainty AS "ec50Uncertainty",
ec50.uncertainty_type AS "ec50UncertaintyType",
ec50.operator_kind AS "ec50OperatorKind",
COALESCE(slope.numeric_value::text,slope.numeric_value::text) AS "slope",
slope.unit_kind AS "slopeUnits",
slope.uncertainty AS "slopeUncertainty",
slope.uncertainty_type AS "slopeUncertaintyType",
slope.operator_kind AS "slopeOperatorKind",
fittedMin.numeric_value AS "fittedMin",
fittedMin.unit_kind AS "fittedMinUnits",
fittedMin.uncertainty AS "fittedMinUncertainty",
fittedMin.uncertainty_type AS "fittedMinUncertaintyType",
fittedMax.numeric_value AS "fittedMax",
fittedMax.unit_kind AS "fittedMaxUnits",
fittedMax.uncertainty AS "fittedMaxUncertainty",
fittedMax.uncertainty_type AS "fittedMaxUncertaintyType",
fittedEC50.numeric_value AS "fittedEC50",
fittedEC50.unit_kind AS "fittedEC50Units",
fittedEC50.uncertainty AS "fittedEC50Uncertainty",
fittedEC50.uncertainty_type AS "fittedEC50UncertaintyType",
fittedSlope.numeric_value AS "fittedSlope",
fittedSlope.uncertainty AS "fittedSlopeUncertainty",
fittedSlope.uncertainty_type AS "fittedSlopeUncertaintyType",
sse.numeric_value AS "sse",
sst.numeric_value AS "sst",
rsquared.numeric_value AS "rSquared",
curveErrorsClob.clob_value AS "curveErrorsClob",
reportedValuesClob.clob_value AS "reportedValuesClob",
parameterStdErrorsClob.clob_value AS "parameterStdErrorsClob",
fitSettings.clob_value AS "fitSettings",
fitSummaryClob.clob_value AS "fitSummaryClob",
userFlagStatus.code_value AS "userFlagStatus",
algorithmFlagStatus.code_value AS "algorithmFlagStatus",
batchCode.code_value AS "batchCode"
FROM 
analysis_group ag
LEFT OUTER JOIN analysis_group_state ags1 
ON ag.id = ags1.analysis_group_id 
AND (ags1.ls_kind='dose response' AND ags1.ls_type='data')
LEFT OUTER JOIN analysis_group_value curveId 
ON ags1.id = curveId.analysis_state_id 
AND (curveId.ls_kind='curve id') 
LEFT OUTER JOIN analysis_group_value curveName 
ON ags1.id = curveName.analysis_state_id 
AND (curveName.ls_kind='curve name') 
LEFT OUTER JOIN analysis_group_value category 
ON ags1.id = category.analysis_state_id 
AND (category.ls_kind='category') 
LEFT OUTER JOIN analysis_group_value renderingHint 
ON ags1.id = renderingHint.analysis_state_id 
AND (renderingHint.ls_kind='Rendering Hint') 
LEFT OUTER JOIN analysis_group_value min 
ON ags1.id = min.analysis_state_id 
AND (min.ls_kind='Min') 
LEFT OUTER JOIN analysis_group_value max 
ON ags1.id = max.analysis_state_id 
AND (max.ls_kind='Max') 
LEFT OUTER JOIN analysis_group_value ec50 
ON ags1.id = ec50.analysis_state_id 
AND (ec50.ls_kind='EC50') 
LEFT OUTER JOIN analysis_group_value slope 
ON ags1.id = slope.analysis_state_id 
AND (slope.ls_kind='Slope') 
LEFT OUTER JOIN analysis_group_value fittedMin 
ON ags1.id = fittedMin.analysis_state_id 
AND (fittedMin.ls_kind='Fitted Min') 
LEFT OUTER JOIN analysis_group_value fittedMax 
ON ags1.id = fittedMax.analysis_state_id 
AND (fittedMax.ls_kind='Fitted Max') 
LEFT OUTER JOIN analysis_group_value fittedEC50 
ON ags1.id = fittedEC50.analysis_state_id 
AND (fittedEC50.ls_kind='Fitted EC50') 
LEFT OUTER JOIN analysis_group_value fittedSlope 
ON ags1.id = fittedSlope.analysis_state_id 
AND (fittedSlope.ls_kind='Fitted Slope') 
LEFT OUTER JOIN analysis_group_value sse 
ON ags1.id = sse.analysis_state_id 
AND (sse.ls_kind='SSE') 
LEFT OUTER JOIN analysis_group_value sst 
ON ags1.id = sst.analysis_state_id 
AND (sst.ls_kind='SST') 
LEFT OUTER JOIN analysis_group_value rsquared 
ON ags1.id = rsquared.analysis_state_id 
AND (rsquared.ls_kind='rSquared') 
LEFT OUTER JOIN analysis_group_value curveErrorsClob 
ON ags1.id = curveErrorsClob.analysis_state_id 
AND (curveErrorsClob.ls_kind='curveErrorsClob') 
LEFT OUTER JOIN analysis_group_value reportedValuesClob 
ON ags1.id = reportedValuesClob.analysis_state_id 
AND (reportedValuesClob.ls_kind='reportedValuesClob') 
LEFT OUTER JOIN analysis_group_value parameterStdErrorsClob 
ON ags1.id = parameterStdErrorsClob.analysis_state_id 
AND (parameterStdErrorsClob.ls_kind='parameterStdErrorsClob') 
LEFT OUTER JOIN analysis_group_value fitSettings 
ON ags1.id = fitSettings.analysis_state_id 
AND (fitSettings.ls_kind='fitSettings') 
LEFT OUTER JOIN analysis_group_value fitSummaryClob 
ON ags1.id = fitSummaryClob.analysis_state_id 
AND (fitSummaryClob.ls_kind='fitSummaryClob') 
LEFT OUTER JOIN analysis_group_value userFlagStatus 
ON ags1.id = userFlagStatus.analysis_state_id 
AND (userFlagStatus.ls_kind='user flag status') 
LEFT OUTER JOIN analysis_group_value algorithmFlagStatus 
ON ags1.id = algorithmFlagStatus.analysis_state_id 
AND (algorithmFlagStatus.ls_kind='algorithm flag status') 
LEFT OUTER JOIN analysis_group_value batchCode 
ON ags1.id = batchCode.analysis_state_id 
AND (batchCode.ls_kind='batch code') 
WHERE ag.ignored='0' and 
ags1.ignored='0' and 
curveId.string_value in (REPLACEME)
```
