### PR TITLE
Set NA to NA_real so data table doesn't warn when using mixed classes

### DIFF
--- a/R/dose_response.R
+++ b/R/dose_response.R
@@ -3059,10 +3059,10 @@ get_goodness_of_fit_thresholds_from_rendering_options<- function(renderingOption
 get_goodness_of_fit_stats_from_fixed_parameters <- function(fixedParams, points, fct) {
       # Calculate the goodness of fit parameters using the 
       # curve fit function and fixed parameters the user has provided
-      SSE <- NA
-      SSR <- NA
-      SST <- NA
-      rSquared <- NA
+      SSE <- NA_real_
+      SSR <- NA_real_
+      SST <- NA_real_
+      rSquared <- NA_real_
       missingParameters <- Filter(f=function(x) x$missing == TRUE, fixedParams)
       if(!is.na(fct) && length(missingParameters) == 0) {
         fct <- eval(parse(text=paste0('function(x) ', fct)))
@@ -3075,7 +3075,7 @@ get_goodness_of_fit_stats_from_fixed_parameters <- function(fixedParams, points,
         SST <- SSR + SSE
         rSquared <- SSR/SST
         if(is.nan(rSquared)) {
-          rSquared <- NA
+          rSquared <- NA_real_
         }
       }
       return(list(SSE = SSE, SSR = SSR, SST = SST, rSquared = rSquared))


### PR DESCRIPTION
## Description
 - If a data table is created with a column of a specific type and you assign a different type, to another row of the same column, it throws a warning.  NA values can have specific types.  This ensures that all returned values from this function are of NA "real" type and "real" numeric values

Without this fix, dose response files which produce NA values for goodness of fit parameters for the first curve in the dataset will produce the following warning to the user:

```
The system has encountered an internal warning, give this message to your system administrator: Group 3 column 'SST': 16310.015276 (type 'double') at RHS position 1
taken as TRUE when assigning to type 'logical'
```


## Related Issue
ACAS-416, ACAS-415

## How Has This Been Tested?
Ran a curve data set which produced NA values in the first curve of the data set for R2, SSE, SSR stat parameters.