### PR TITLE
Special character in xlsx causing differing row error

### DIFF
--- a/R/fileRead.R
+++ b/R/fileRead.R
@@ -43,6 +43,10 @@ readExcelOrCsv <- function(filePath, sheet = 1, header = FALSE) {
   if (grepl("\\.xlsx?$",filePath)) {
     output <- tryCatch({
       wb <- XLConnect::loadWorkbook(filePath)
+
+      # If a "" is dectected, then set this to NA
+      XLConnect::setMissingValue(wb, value = c(""))
+      
       sheetToRead <- which(unlist(lapply(XLConnect::getSheets(wb), XLConnect::isSheetVisible, object = wb)))[sheet]
       return(XLConnect::readWorksheet(wb, sheet = sheetToRead, header = header, dateTimeFormat="%Y-%m-%d"))
     }, error = function(e) {

--- a/R/fileRead.R
+++ b/R/fileRead.R
@@ -44,7 +44,7 @@ readExcelOrCsv <- function(filePath, sheet = 1, header = FALSE) {
     output <- tryCatch({
       wb <- XLConnect::loadWorkbook(filePath)
 
-      # If a "" is dectected, then set this to NA
+      # If a "" is detected, then set this to NA
       XLConnect::setMissingValue(wb, value = c(""))
       
       sheetToRead <- which(unlist(lapply(XLConnect::getSheets(wb), XLConnect::isSheetVisible, object = wb)))[sheet]


### PR DESCRIPTION
## Description
**Steps to Reproduce:**
Uploading the attached xlsx file to ACAS
**Expected Results:**
ACAS uploads to file correctly ignoring the "Notes" column which appears to be empty
**Actual Results:**
ACAS throws the following error to the user:
```
Errors: 1arguments imply differing number of rows: 3, 4
```
And in the rservices logs:
```
acas-rservices-1  | 2022-08-29 20:42:47 ERROR:com.mcneilco.acas.genericDataParser:arguments imply differing number of rows: 3, 4
acas-rservices-1  | 2022-08-29 20:42:47 ERROR:com.mcneilco.acas.genericDataParser:Traceback:
acas-rservices-1  | 1: runFunction()
acas-rservices-1  | c("2: runMain(pathToGenericDataFormatExcelFile, reportFilePath = reportFilePath, ", "2:     dryRun = dryRun, developmentMode = developmentMode, configList = configList, ", "2:     testMode = testMode, recordedBy = recordedBy, imagesFile = imagesFile, ", "2:     moduleName = moduleName, errorEnv = errorEnv)")
acas-rservices-1  | c("3: organizeCalculatedResults(calculatedResults, inputFormat, formatParameters, ", "3:     mainCode, lockCorpBatchId = formatParameters$lockCorpBatchId, ", "3:     rawOnlyFormat = rawOnlyFormat, errorEnv = errorEnv, precise = precise, ", "3:     calculateGroupingID = calculateGroupingID)")
acas-rservices-1  | 4: cbind(valueKinds, hideColumn, conditionColumn)
acas-rservices-1  | 5: cbind(deparse.level, ...)
acas-rservices-1  | 6: data.frame(..., check.names = FALSE)
acas-rservices-1  | c("7: stop(gettextf(\"arguments imply differing number of rows: %s\", ", "7:     paste(unique(nrows), collapse = \", \")), domain = NA)")
acas-rservices-1  | 2022-08-29 20:42:47 ERROR:com.mcneilco.acas.genericDataParser:R frames dumped to: /tmp/file2570133cb0.rda
acas-rservices-1  | 2022-08-29 20:42:47 INFO:com.acas.runrfunction:Loading required package: brew
acas-rservices-1  | Running apache "acas-acas-1.acas_default - - [29/Aug/2022:20:42:46 +0000] "POST /r-services-api/runfunction HTTP/1.1" 200 585 "-" "-"" combined
```

## Related Issue
ACAS-421

## How Has This Been Tested?
added acas client tests and ran all other acasclient tests