### PR TITLE
ACAS-587/ACAS-493: upgrade to nodejs 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcneilco/acas-r-repo:2023.1.0
 # NODE
 USER root
 ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_VERSION 14.x
+ENV NODE_VERSION 18.x
 RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
   dnf install -y nodejs && \
   npm install -g coffeescript@2.5.1 properties@1.2.1 underscore@1.12.0 underscore-deep-extend@1.1.5 properties-parser@0.3.1 flat@5.0.2 glob@7.1.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM mcneilco/acas-r-repo:2022.4.x
 
+# NODE
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_VERSION 14.x
+RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
+  dnf install -y nodejs && \
+  npm install -g coffeescript@2.5.1 properties@1.2.1 underscore@1.12.0 underscore-deep-extend@1.1.5 properties-parser@0.3.1 flat@5.0.2 glob@7.1.6
+ENV NODE_PATH /usr/lib/node_modules
+
 ENV LANG en_US.UTF-8
 ENV LC_ALL C.UTF-8
 COPY --chown=runner:runner . /home/runner/racas

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcneilco/acas-r-repo:1.13.7
+FROM mcneilco/acas-r-repo:2022.4.x
 
 ENV LANG en_US.UTF-8
 ENV LC_ALL C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM mcneilco/acas-r-repo:2022.4.x
+FROM mcneilco/acas-r-repo:2023.1.0
 
 # NODE
+USER root
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_VERSION 14.x
 RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
   dnf install -y nodejs && \
   npm install -g coffeescript@2.5.1 properties@1.2.1 underscore@1.12.0 underscore-deep-extend@1.1.5 properties-parser@0.3.1 flat@5.0.2 glob@7.1.6
+USER runner
 ENV NODE_PATH /usr/lib/node_modules
 
 ENV LANG en_US.UTF-8

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -60,7 +60,7 @@ RUN \
 
 # NODE
 ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_VERSION 14.x
+ENV NODE_VERSION 18.x
 RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
   dnf install -y nodejs && \
   npm install -g coffeescript@2.5.1 properties@1.2.1 underscore@1.12.0 underscore-deep-extend@1.1.5 properties-parser@0.3.1 flat@5.0.2 glob@7.1.6

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -58,14 +58,6 @@ RUN \
 RUN \
   chkconfig httpd off
 
-# NODE
-ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_VERSION 18.x
-RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
-  dnf install -y nodejs && \
-  npm install -g coffeescript@2.5.1 properties@1.2.1 underscore@1.12.0 underscore-deep-extend@1.1.5 properties-parser@0.3.1 flat@5.0.2 glob@7.1.6
-ENV NODE_PATH /usr/lib/node_modules
-
 RUN wget https://github.com/stevengj/nlopt/archive/v2.7.1.tar.gz && \
     tar -xzvf v2.7.1.tar.gz && \
     cd nlopt-2.7.1 && \

--- a/README.md
+++ b/README.md
@@ -6,32 +6,32 @@ This proved to be the most efficient way as qemu has some serious lag issues wit
 
 On armd64 v8 system:
 ```
-docker build -t mcneilco/acas-r-repo:1.13.7-linuxarm64v8 -f Dockerfile.repo .
+docker build --platform linux/arm64/v8 -t mcneilco/acas-r-repo:2023.1.0-linuxarm64v8 -f Dockerfile.repo .
 
-docker push mcneilco/acas-r-repo:1.13.7-linuxarm64v8
+docker push mcneilco/acas-r-repo:2023.1.0-linuxarm64v8
 ```
 
 On amd64 system:
 ```
-docker build -t mcneilco/acas-r-repo:1.13.7-linuxamd64 -f Dockerfile.repo .
+docker build --platform linux/amd64 -t mcneilco/acas-r-repo:2023.1.0-linuxamd64 -f Dockerfile.repo .
 
-docker push mcneilco/acas-r-repo:1.13.7-linuxamd64
+docker push mcneilco/acas-r-repo:2023.1.0-linuxamd64
 ```
 
 On either system:
 
 ```
-docker pull mcneilco/acas-r-repo:1.13.7-linuxamd64 
-docker pull mcneilco/acas-r-repo:1.13.7-linuxarm64v8
+docker pull mcneilco/acas-r-repo:2023.1.0-linuxamd64 
+docker pull mcneilco/acas-r-repo:2023.1.0-linuxarm64v8
 
-docker manifest rm mcneilco/acas-r-repo:1.13.7
+docker manifest rm mcneilco/acas-r-repo:2023.1.0
 
 docker manifest create \
-mcneilco/acas-r-repo:1.13.7 \
---amend mcneilco/acas-r-repo:1.13.7-linuxamd64 \
---amend mcneilco/acas-r-repo:1.13.7-linuxarm64v8
+mcneilco/acas-r-repo:2023.1.0 \
+--amend mcneilco/acas-r-repo:2023.1.0-linuxamd64 \
+--amend mcneilco/acas-r-repo:2023.1.0-linuxarm64v8
 
-docker manifest push mcneilco/acas-r-repo:1.13.7
+docker manifest push mcneilco/acas-r-repo:2023.1.0
 ```
 
 ### Using buildx multi platform builds
@@ -39,7 +39,7 @@ docker manifest push mcneilco/acas-r-repo:1.13.7
 This is much simpler but qemu is extremely slow when building multiarch packages.
 
 ```
-docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t mcneilco/acas-r-repo:1.13.7 -f Dockerfile.repo .
+docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t mcneilco/acas-r-repo:2023.1.0 -f Dockerfile.repo .
 ```
 
 
@@ -47,5 +47,5 @@ docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t mcneilco/aca
 
 This is currently done via automated builds but this command should be equivalent to the current build process
 ```
-docker buildx build --push --no-cache --platform linux/amd64,linux/arm64/v8 -t mcneilco/racas-oss:1.13.7 .
+docker buildx build --push --no-cache --platform linux/amd64,linux/arm64/v8 -t mcneilco/racas-oss:2023.1.0 .
 ```


### PR DESCRIPTION
## Description
 - Upgrade to nodejs 18
 - Move Nodejs installation from Dockerfile.repo to Dockerfile to avoid having to rebuild R packages when updating nodejs versions
 - Built a multi-arch build mcneilco/acas-r-repo:2023.1.0 and pushed it
 - Updated the README to include current build instructions for mcneilco/acas-r-repo

## Related Issue
ACAS-493

## How Has This Been Tested?
Ran local build and acasclient tests pass.