### PR TITLE
ACAS-525: Add optional high priority warningings to the top of warnings

### DIFF
--- a/R/errorLogging.R
+++ b/R/errorLogging.R
@@ -129,9 +129,12 @@ stopUserAndLogInvalidJSON <- function (logName, logFileName, url, response, meth
 #'you will get an error if you try \code{warnUser("text ", variable, " text")}. Use paste0 
 #'instead: \code{warnUser(paste0("text ", variable, " text"))} (note that this syntax is also 
 #'perfectly acceptable inside \code{warning})
-warnUser <- function(message) {
+warnUser <- function(message, highPriority = FALSE) {
   w <- simpleWarning(message)
   class(w) <- c(class(w), "userWarning")
+  if(highPriority) {
+    class(w) <- c(class(w), "userWarningHighPriority")
+  }
   warning(w)
 }
 

--- a/R/messenger.R
+++ b/R/messenger.R
@@ -131,7 +131,12 @@ Messenger <- setRefClass(Class = "Messenger",
                              if(!inherits(x, "warning")) {
                                x <- simpleWarning(x)
                              }
-                             warnings <<- c(warnings, list(x))
+                             # Add high priority warnings to the top of the list
+                             if(inherits(x, "userWarningHighPriority")) {
+                               warnings <<- c(list(x), warnings)
+                             } else {
+                               warnings <<- c(warnings, list(x))
+                             }
                            },
                            addInfo = function(x) {
                              if(!inherits(x, "message")) {


### PR DESCRIPTION
## Description
 - Added new optional "highPriority" boolean to warnUser which adds the warning to the top of the list rather than the bottom

## Related Issue
ACAS-525

## How Has This Been Tested?
Uploaded an experiment which already existed and verified the message was at the top of the multiple warnings where previously it had been at the bottom