### PR TITLE
ACAS-709: Fix for dose response validation images not rendering due t…

### DIFF
--- a/inst/rmd/doseResponseCurveValidation.rmd
+++ b/inst/rmd/doseResponseCurveValidation.rmd
@@ -35,5 +35,9 @@ tbody <- paste0(tbody,trs)
 tbody <- paste0(tbody,"</tbody>" )
 table <- paste0(table,tbody)
 table <- paste0(table,"</table>" )
+
+# Include the =html escape as we are outputting raw html. This is needed to prevent the html from being rendered by markdownToHTML and converting characters like 1/9 to html codes
+cat('```{=html}\n')
 cat(table)
+cat('\n```')
 ```


### PR DESCRIPTION
## Description
 - When validating dose response curves, R writes markdown to a file which includes html.  When the markdown file is converted to full html by markdown::markdownToHTML, certain characters are converted to their html code equivalents.  Specifically 1/9 is converted to e.g. ⅑ https://en.wikipedia.org/wiki/Number_Forms . This breaks the base64 encoded images in the dose response validation page in ACAS.
 - This change adds the {=html} escape sequence to the markdown template:
   - Markdown: https://bookdown.org/yihui/rmarkdown-cookbook/raw-content.html#raw-content
   - Pandoc: https://pandoc.org/MANUAL.html#extension-raw_attribute
 - I have not yet determined when this bug was introduced but I'm pretty sure it was a change we picked up in pandoc and I haven't determined yet which versions are affected besides knowing it between 2023.1.x and 2023.2.1

## Related Issue
ACAS-709

## How Has This Been Tested?
 - Ran dose response validation with a file/server on 2023.2.1 and witnessed the issue (broken image links)
<img width="230" alt="Screenshot 2023-10-13 at 10 26 32 AM" src="https://github.com/mcneilco/racas/assets/868119/92cfba92-ca13-4ba6-943b-1a032bbad1c0">

 - Manually updated stage server by updating the running copy of the file at `/home/runner/build/r_libs/racas/rmd/doseResponseCurveValidation.rmd`
 - Verified that all images rendered properly and that the html was no longer including bad characters in the base64 encoded images.
<img width="456" alt="Screenshot 2023-10-13 at 10 26 38 AM" src="https://github.com/mcneilco/racas/assets/868119/9eb83d8b-387c-4335-be5b-f9f4e3b92f49">


