### PR TITLE
ACAS-774: Switch the centos9 stream

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: racas
 Type: Package
 Title: R Package for ACAS
 Version: 1.15.0
-Date: 2022-02-16
+Date: 2024-06-04
 Author: Brian Bolt
 Maintainer: Brian Bolt <brian.bolt@boltengineered.com.com>
 Description: R Package for ACAS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 FROM mcneilco/acas-r-repo:2024.1.0
 
 USER root
-# EOL for Centos8-Stream workaround 
-RUN sed -i 's/^mirrorlist=/#&/' /etc/yum.repos.d/*.repo && \
-    sed -i 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/*.repo && \ 
-    sed -i 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo 
-
 # NODE
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_VERSION 20.x

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcneilco/acas-r-repo:2023.1.0
+FROM mcneilco/acas-r-repo:2024.1.0
 
 # NODE
 USER root

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -1,6 +1,6 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-# R, Java
+# R-Java
 ENV JAVA_VERSION 1.8.0
 ENV JAVA_HOME /usr/lib/jvm/java
 RUN echo "$JAVA_HOME/jre/lib/$(arch)/server/" > /etc/ld.so.conf.d/rApache_rJava.conf && \
@@ -9,19 +9,18 @@ RUN echo "$JAVA_HOME/jre/lib/$(arch)/server/" > /etc/ld.so.conf.d/rApache_rJava.
 
 RUN \
   echo "fastestmirror=1" >> /etc/dnf/dnf.conf && \
-  sed -i 's/vault.centos.org/archive.kernel.org/g' /etc/yum.repos.d/* && \
   dnf update -y && \
   dnf upgrade -y && \
   dnf install -y epel-release && \
-  dnf config-manager --set-enabled powertools && \
-  dnf module enable -y postgresql:13 && \
-  dnf install postgresql-server-devel postgresql-devel postgresql -y && \
-  dnf install -y rpm-build which make wget tar httpd-devel libapreq2-devel libcurl-devel protobuf-devel openssl-devel libpng-devel java-1.8.0-openjdk java-1.8.0-openjdk-devel curl-devel libxml2-devel llvm5.0-devel llvm-toolset sudo cmake initscripts && \
+  dnf config-manager --set-enabled crb && \
+  dnf module enable -y postgresql:15 && \
+  dnf install postgresql libpq libpq-devel -y && \
+  dnf install -y rpm-build which make wget tar httpd-devel libapreq2-devel libcurl-devel openssl-devel libpng-devel java-1.8.0-openjdk java-1.8.0-openjdk-devel curl-devel libxml2-devel llvm-devel llvm-toolset sudo cmake initscripts && \
   dnf builddep -y R-devel && \
   dnf install -y MTA mod_ssl /usr/sbin/semanage && \
   dnf clean all
 
-ENV R_VERSION 4.1.2
+ENV R_VERSION 4.4.0
 RUN curl -O https://cran.rstudio.com/src/base/R-4/R-${R_VERSION}.tar.gz && \
     tar -xzvf R-${R_VERSION}.tar.gz && \
     cd R-${R_VERSION} && \
@@ -54,14 +53,14 @@ RUN \
     --with-apreq2-config=/usr/bin/apreq2-config && \
   make && \
   make install
-  
-RUN \
-  chkconfig httpd off
 
 RUN wget https://github.com/stevengj/nlopt/archive/v2.7.1.tar.gz && \
     tar -xzvf v2.7.1.tar.gz && \
     cd nlopt-2.7.1 && \
     cmake . && make && sudo make install
+ENV LD_LIBRARY_PATH /nlopt-2.7.1:${LD_LIBRARY_PATH}
+# Run ldconfig to update the shared library cache
+RUN ldconfig
 
 RUN	useradd -u 1000 -ms /bin/bash runner
 ENV ACAS_HOME /home/runner/build

--- a/R/dose_response.R
+++ b/R/dose_response.R
@@ -713,8 +713,8 @@ curve_fit_controller_fitData_dataTable_to_fitData <- function(serviceDataTable) 
                                                                                                                            list(list()),
                                                                                                                            TRUE,
                                                                                                                            list(list()))]
-  serviceDataTable[!exists("userFlagStatus") || is.na(userFlagStatus), userFlagStatus := ""]
-  serviceDataTable[!exists("algorithmFlagStatus") || is.na(algorithmFlagStatus), algorithmFlagStatus := ""]
+  serviceDataTable[!exists("userFlagStatus") | is.na(userFlagStatus), userFlagStatus := ""]
+  serviceDataTable[!exists("algorithmFlagStatus") | is.na(algorithmFlagStatus), algorithmFlagStatus := ""]
   serviceDataTable[ , model.synced := FALSE]
   return(serviceDataTable)
 }

--- a/R/fileRead.R
+++ b/R/fileRead.R
@@ -108,9 +108,14 @@ getFileEncoding <- function(filePath) {
   # "\xff\xfe" is the byte order mark for "UTF-16LE"
   # Referenced from the answer by 'roippi' in this question thread:
   # http://stackoverflow.com/questions/23729151/reading-text-file-into-variable-subsequent-print-returns-escape-characters
-  fileEncoding <- ifelse(suppressWarnings(grepl("\xff\xfe",readLines(filePath, n=1), perl = TRUE)), 
-                         "UTF-16LE", 
-                         "")
+  # Read the first few bytes of the file in raw mode
+  firstBytes <- readBin(filePath, "raw", n = 2)
+
+  # Convert the raw bytes to a character string
+  firstBytesStr <- rawToChar(firstBytes)
+
+  # Check if the first bytes match the BOM for UTF-16 Little Endian encoding
+  fileEncoding <- ifelse(firstBytesStr == "\xff\xfe", "UTF-16LE", "")
   return(fileEncoding)
 }
 

--- a/README.md
+++ b/README.md
@@ -6,32 +6,32 @@ This proved to be the most efficient way as qemu has some serious lag issues wit
 
 On armd64 v8 system:
 ```
-docker build --platform linux/arm64/v8 -t mcneilco/acas-r-repo:2023.1.0-linuxarm64v8 -f Dockerfile.repo .
+docker build --platform linux/arm64/v8 -t mcneilco/acas-r-repo:2024.1.0-linuxarm64v8 -f Dockerfile.repo .
 
-docker push mcneilco/acas-r-repo:2023.1.0-linuxarm64v8
+docker push mcneilco/acas-r-repo:2024.1.0-linuxarm64v8
 ```
 
 On amd64 system:
 ```
-docker build --platform linux/amd64 -t mcneilco/acas-r-repo:2023.1.0-linuxamd64 -f Dockerfile.repo .
+docker build --platform linux/amd64 -t mcneilco/acas-r-repo:2024.1.0-linuxamd64 -f Dockerfile.repo .
 
-docker push mcneilco/acas-r-repo:2023.1.0-linuxamd64
+docker push mcneilco/acas-r-repo:2024.1.0-linuxamd64
 ```
 
 On either system:
 
 ```
-docker pull mcneilco/acas-r-repo:2023.1.0-linuxamd64 
-docker pull mcneilco/acas-r-repo:2023.1.0-linuxarm64v8
+docker pull mcneilco/acas-r-repo:2024.1.0-linuxamd64 
+docker pull mcneilco/acas-r-repo:2024.1.0-linuxarm64v8
 
-docker manifest rm mcneilco/acas-r-repo:2023.1.0
+docker manifest rm mcneilco/acas-r-repo:2024.1.0
 
 docker manifest create \
-mcneilco/acas-r-repo:2023.1.0 \
---amend mcneilco/acas-r-repo:2023.1.0-linuxamd64 \
---amend mcneilco/acas-r-repo:2023.1.0-linuxarm64v8
+mcneilco/acas-r-repo:2024.1.0 \
+--amend mcneilco/acas-r-repo:2024.1.0-linuxamd64 \
+--amend mcneilco/acas-r-repo:2024.1.0-linuxarm64v8
 
-docker manifest push mcneilco/acas-r-repo:2023.1.0
+docker manifest push mcneilco/acas-r-repo:2024.1.0
 ```
 
 ### Using buildx multi platform builds
@@ -39,7 +39,7 @@ docker manifest push mcneilco/acas-r-repo:2023.1.0
 This is much simpler but qemu is extremely slow when building multiarch packages.
 
 ```
-docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t mcneilco/acas-r-repo:2023.1.0 -f Dockerfile.repo .
+docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t mcneilco/acas-r-repo:2024.1.0 -f Dockerfile.repo .
 ```
 
 
@@ -47,5 +47,5 @@ docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t mcneilco/aca
 
 This is currently done via automated builds but this command should be equivalent to the current build process
 ```
-docker buildx build --push --no-cache --platform linux/amd64,linux/arm64/v8 -t mcneilco/racas-oss:2023.1.0 .
+docker buildx build --push --no-cache --platform linux/amd64,linux/arm64/v8 -t mcneilco/racas-oss:2024.1.0 .
 ```

--- a/inst/bin/setenv.sh
+++ b/inst/bin/setenv.sh
@@ -1,7 +1,14 @@
 # Example:
 #export LD_LIBRARY_PATH=/usr/lib/oracle/11.2/client64/lib:$LD_LIBRARY_PATH
-LD_LIBRARY_PATH=/usr/lib/jvm/java-1.8.0/jre/lib/amd64:/usr/lib/jvm/java-1.8.0/jre/lib/amd64/server/
-PATH=/usr/pgsql-9.4/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ARCH=$(uname -m)
+
+if [ "$ARCH" = "x86_64" ]; then
+    LD_LIBRARY_PATH=/usr/lib/jvm/java-1.8.0/jre/lib/amd64:/usr/lib/jvm/java-1.8.0/jre/lib/amd64/server/:/R-4.4.0/lib
+elif [ "$ARCH" = "aarch64" ]; then
+    LD_LIBRARY_PATH=/usr/lib/jvm/java-1.8.0/jre/lib/aarch64:/usr/lib/jvm/java-1.8.0/jre/lib/aarch64/server/:/R-4.4.0/lib
+fi
+
+export LD_LIBRARY_PATH
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 R_LIBS=/home/runner/build/r_libs
 JAVA_HOME=/usr/lib/jvm/java-1.8.0
-if [ -e  "/opt/rh/rh-python36/enable" ]; then source /opt/rh/rh-python36/enable; fi;


### PR DESCRIPTION
## Description
 - These changes may need some discussion, they are fixing a critical EOL of centos8 stream but they are fairly substantial upgrades and changes to be introduced into a patch of 2024.1.x.  The acasclient tests are fairly substantial as they test a lot of different experiment load types but these changes do have risks.

Changes;
 - Use centos9 stream instead of EOLed centos8 stream
 - Updated to postgres 15 libraries as finding and installing older postgres 13 was harder than just upgrading
 - Update R to 4.4.0 (April, 2024) from 4.1.0 (November, 2021) https://cran.r-project.org/src/base/R-4
   -  R doesn't have a great way of downloading older versions of packages which are compatible with the older version of R so updating to 4.4.0 was easiest by a long shot. Microsoft used to maintain a package Time Machine called MRAN but they stopped maintaining it unfortunately (https://techcommunity.microsoft.com/t5/azure-sql-blog/microsoft-r-application-network-retirement/ba-p/3707161)
   - There are a few breaking changes in R which I noted in my PR review inline here.


## Related Issue
ACAS-774

## How Has This Been Tested?
See testing notes here https://github.com/mcneilco/acas/pull/1165 