### PR TITLE
ACAS-744: Switch to vault.centos.org as a workaround to keep using stream8 past EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM mcneilco/acas-r-repo:2023.1.0
 
-# NODE
 USER root
+# EOL for Centos8-Stream workaround 
+RUN sed -i 's/^mirrorlist=/#&/' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/*.repo && \ 
+    sed -i 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo 
+
+# NODE
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_VERSION 18.x
 RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \


### PR DESCRIPTION
## Description
 - Switches all references from mirror to vault

## Related Issue
ACAS-744

## How Has This Been Tested?
TBD