### PR TITLE
Override mostRecentCurveColor and fix curve sort order

### DIFF
--- a/R/rendering.R
+++ b/R/rendering.R
@@ -496,24 +496,21 @@ plotCurve <- function(curveData, params, outFile = NA, ymin = NA, logDose = FALS
   } else if(mostRecentCurveColor == "none") {
       #requestor wants to override global configuration
       mostRecentCurveColor <- NA
-  }
+    }
   
-  if("recordedDate" %in% names(params)) {
-    params <- params[order(params$recordedDate, decreasing = TRUE),]
-  }
   if(!"color" %in% names(params)) {
     if(nrow(params) > 1 && !is.na(mostRecentCurveColor)) {
       # mostRecentCurveColor in effect. Move the most recent curve to the end of the list
       # so that it shows on top of the other curves
-      # Identify the index of the record with the most recent recordedDate
-      most_recent_index <- which.max(params$recordedDate)
-      # Extract the most recent record
-      most_recent_record <- params[most_recent_index, ]
-      # Remove the most recent record from the original dataframe
-      params <- params[-most_recent_index, ]
-      # Append the most recent record to the end of the dataframe
-      params <- rbind(params, most_recent_record)
-
+      if("recordedDate" %in% names(params)) {
+        # Identify the index of the record with the most recent recordedDate
+        most_recent_index <- which.max(params$recordedDate)
+        most_recent_record <- params[most_recent_index, ]
+        # Remove the most recent record from the original dataframe
+        params <- params[-most_recent_index, ]
+        # Append the most recent record to the end of the dataframe
+        params <- rbind(params, most_recent_record)
+      }
       params$color <- rep_len(plotColors, nrow(params))
       params[nrow(params), "color"] <- mostRecentCurveColor
     } else {

--- a/R/rendering.R
+++ b/R/rendering.R
@@ -496,14 +496,14 @@ plotCurve <- function(curveData, params, outFile = NA, ymin = NA, logDose = FALS
   } else if(mostRecentCurveColor == "none") {
       #requestor wants to override global configuration
       mostRecentCurveColor <- NA
-    }
+  }
   
   if(!"color" %in% names(params)) {
     if(nrow(params) > 1 && !is.na(mostRecentCurveColor)) {
       # mostRecentCurveColor in effect. Move the most recent curve to the end of the list
       # so that it shows on top of the other curves
+      params$color <- rep_len(plotColors, nrow(params))
       if("recordedDate" %in% names(params)) {
-        # Identify the index of the record with the most recent recordedDate
         most_recent_index <- which.max(params$recordedDate)
         most_recent_record <- params[most_recent_index, ]
         # Remove the most recent record from the original dataframe
@@ -511,7 +511,6 @@ plotCurve <- function(curveData, params, outFile = NA, ymin = NA, logDose = FALS
         # Append the most recent record to the end of the dataframe
         params <- rbind(params, most_recent_record)
       }
-      params$color <- rep_len(plotColors, nrow(params))
       params[nrow(params), "color"] <- mostRecentCurveColor
     } else {
       params$color <- rep_len(plotColors,nrow(params))

--- a/R/rendering.R
+++ b/R/rendering.R
@@ -482,31 +482,36 @@ plotCurve <- function(curveData, params, outFile = NA, ymin = NA, logDose = FALS
           function(x) 
             rgb(x[1], x[2], x[3], alpha=alpha))  
   }
-  if(is.null(plotColors) | length(plotColors) == 0) {
+
+  if (length(plotColors) > 1) {
+    requestedColors <- TRUE
+  } else if(is.null(plotColors) | length(plotColors) == 0) {
+    requestedColors <- FALSE
     plotColors <- "black"
     if(!is.null(racas::applicationSettings$server.curveRender.plotColors) && racas::applicationSettings$server.curveRender.usePlotColorsByDefault) {
       plotColors <- trimws(strsplit(racas::applicationSettings$server.curveRender.plotColors,",")[[1]])
     }
   }
 
-  if(is.na(mostRecentCurveColor)) {
+  if(is.na(mostRecentCurveColor && !requestedColors)) {
     if(!is.null(racas::applicationSettings$server.curveRender.mostRecentCurveColor) && racas::applicationSettings$server.curveRender.mostRecentCurveColor != "") {
       mostRecentCurveColor <- trimws(racas::applicationSettings$server.curveRender.mostRecentCurveColor)
     }
   }
   
-  if("recordedDate" %in% names(params)) {
-    params <- params[order(params$recordedDate, decreasing = TRUE),]
+  if("recordedDate" %in% names(params)  && !requestedColors) {
+    params <- params[order(params$recordedDate, decreasing = FALSE),]
   }
   if(!"color" %in% names(params)) {
-    if(nrow(params) > 1 && !is.na(mostRecentCurveColor)) {
-      params$color <- mostRecentCurveColor
-      params[2:nrow(params), ]$color <- rep_len(plotColors,nrow(params)-1)
+    if(nrow(params) > 1 && !is.na(mostRecentCurveColor) && !requestedColors) {
+      params$color <- rep_len(plotColors, nrow(params))
+      params[nrow(params), "color"] <- mostRecentCurveColor
     } else {
       params$color <- rep_len(plotColors,nrow(params))
-  #     params$color <- grDevices::cm.colors(nrow(params), alpha = 1)
     }
   }
+
+
   plotColorsAlpha <- add.alpha(params$color, alpha=0.3)
   curveData$color <- params$color[match(curveData$curveId,params$curveId)] 
   curveData$coloralpha <- plotColorsAlpha[match(curveData$curveId,params$curveId)] 


### PR DESCRIPTION
##Description
This change addresses two issues:

The curve overlays area sorted by modified date descending. This puts the most recent curves under all the others. This matters when using the mostRecentCurveColor feature - it bury's the newest curve under the others
If you want to highlight a specific curve, not necessarily the most recently modified, we could use the plotColors list, but the mostRecentCurveColor steps on it. I modified to the code to override that features when plotColors are provided
##Related Issue
This is tracked in a customer Jira system

##How Has This Been Tested?
I have been testing this locally against about 10 experiments. I need a merge here to deploy to the customer's official test system