### PR TITLE
ACAS-967: Switch racas base image to UBI9 `ubi-minimal` runtime base image via multistage build

### DIFF
--- a/.github/workflows/rebuild-base-image.yml
+++ b/.github/workflows/rebuild-base-image.yml
@@ -26,6 +26,7 @@ on:
       - master
       - 'release/**'
       - ACAS-967-scheduled-rebuilds
+      - ACAS-967-slimmer-base
 
 jobs:
   # Determine which branches to build

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -115,6 +115,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
 RUN microdnf install -y \
     # Apache for rapache (libapreq2 copied from builder)
     httpd \
+    # Basic utilities needed by R
+    which \
     # Java 1.8 for rJava (same as builder)
     java-1.8.0-openjdk-headless \
     # PostgreSQL client libs (for RPostgreSQL)

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -105,38 +105,39 @@ RUN --mount=type=cache,target=/home/runner/.cache/R/renv,uid=1000,id=renv-$TARGE
       renv::restore(library = lib, prompt = FALSE)"
 
 # =============================================================================
-# STAGE 2: Runtime (Debian Slim)
-# Minimal runtime with only what's needed to run R/rapache
+# STAGE 2: Runtime (UBI9 Minimal)
+# Minimal RHEL-based runtime - same distro family as builder for compatibility
 # =============================================================================
-FROM debian:bookworm-slim AS runtime
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
 
-# Runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    # Apache for rapache
-    apache2 \
-    libaprutil1 \
-    # Java 17 for rJava (Java 8 not in Debian Bookworm)
-    openjdk-17-jre-headless \
+# Runtime dependencies (RHEL packages via microdnf)
+RUN microdnf install -y \
+    # Apache + libapreq2 for rapache
+    httpd \
+    libapreq2 \
+    # Java 1.8 for rJava (same as builder)
+    java-1.8.0-openjdk-headless \
     # PostgreSQL client libs (for RPostgreSQL)
-    libpq5 \
+    libpq \
     # R runtime dependencies (from ldd analysis)
-    libtirpc3 \
-    libpcre2-8-0 \
-    libdeflate0 \
-    liblzma5 \
-    libbz2-1.0 \
-    zlib1g \
-    libgomp1 \
-    libgfortran5 \
-    libreadline8 \
-    libcurl4 \
+    pcre2 \
+    libdeflate \
+    xz-libs \
+    bzip2-libs \
+    zlib \
+    libicu \
+    libgomp \
+    libgfortran \
+    readline \
+    libcurl \
     libxml2 \
-    libpng16-16 \
-    libssl3 \
+    libpng \
+    openssl-libs \
+    libtirpc \
     # Fonts (for R plots)
     fontconfig \
-    fonts-dejavu-core \
-    && rm -rf /var/lib/apt/lists/*
+    dejavu-sans-fonts \
+    && microdnf clean all
 
 # Create runner user (match UID from builder)
 RUN useradd -u 1000 -ms /bin/bash runner
@@ -149,26 +150,17 @@ RUN ln -s /opt/R/4.4.0/bin/R /usr/local/bin/R && \
 # Copy R packages from builder
 COPY --from=builder --chown=runner:runner /home/runner/build/r_libs /home/runner/build/r_libs
 
-# Copy rapache module (Debian uses different Apache module path)
-COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib/apache2/modules/mod_R.so
+# Copy rapache module (same path as builder since same distro family)
+COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib64/httpd/modules/mod_R.so
 
-# Copy libapreq2 (not available in Debian repos)
-COPY --from=builder /lib64/libapreq2.so.3* /usr/lib/
-
-# Copy ICU libs from builder (R compiled against CentOS ICU 67, Debian has 72)
-COPY --from=builder /lib64/libicuuc.so.67* /usr/lib/
-COPY --from=builder /lib64/libicui18n.so.67* /usr/lib/
-COPY --from=builder /lib64/libicudata.so.67* /usr/lib/
-
-# Copy and relocate nlopt to standard library path
+# Copy nlopt (not in UBI repos, keep from builder)
 COPY --from=builder /nlopt-2.7.1/libnlopt.so.0.11.1 /usr/local/lib/
 RUN ln -s /usr/local/lib/libnlopt.so.0.11.1 /usr/local/lib/libnlopt.so.0 && \
     ln -s /usr/local/lib/libnlopt.so.0 /usr/local/lib/libnlopt.so && \
     ldconfig
 
 # Environment setup
-ARG TARGETARCH
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH:-amd64}
+ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
 ENV R_VERSION=4.4.0
 ENV R_LIBS=/home/runner/build/r_libs
 ENV ACAS_HOME=/home/runner/build

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -105,39 +105,38 @@ RUN --mount=type=cache,target=/home/runner/.cache/R/renv,uid=1000,id=renv-$TARGE
       renv::restore(library = lib, prompt = FALSE)"
 
 # =============================================================================
-# STAGE 2: Runtime (UBI9 Minimal)
-# Minimal RHEL-based runtime - same distro family as builder for compatibility
+# STAGE 2: Runtime (Debian Slim)
+# Minimal runtime with only what's needed to run R/rapache
 # =============================================================================
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
+FROM debian:bookworm-slim AS runtime
 
-# Runtime dependencies (RHEL packages via microdnf)
-RUN microdnf install -y \
-    # Apache + libapreq2 for rapache
-    httpd \
-    libapreq2 \
-    # Java 1.8 for rJava (same as builder)
-    java-1.8.0-openjdk-headless \
+# Runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Apache for rapache
+    apache2 \
+    libaprutil1 \
+    # Java 17 for rJava (Java 8 not in Debian Bookworm)
+    openjdk-17-jre-headless \
     # PostgreSQL client libs (for RPostgreSQL)
-    libpq \
+    libpq5 \
     # R runtime dependencies (from ldd analysis)
-    pcre2 \
-    libdeflate \
-    xz-libs \
-    bzip2-libs \
-    zlib \
-    libicu \
-    libgomp \
-    libgfortran \
-    readline \
-    libcurl \
+    libtirpc3 \
+    libpcre2-8-0 \
+    libdeflate0 \
+    liblzma5 \
+    libbz2-1.0 \
+    zlib1g \
+    libgomp1 \
+    libgfortran5 \
+    libreadline8 \
+    libcurl4 \
     libxml2 \
-    libpng \
-    openssl-libs \
-    libtirpc \
+    libpng16-16 \
+    libssl3 \
     # Fonts (for R plots)
     fontconfig \
-    dejavu-sans-fonts \
-    && microdnf clean all
+    fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create runner user (match UID from builder)
 RUN useradd -u 1000 -ms /bin/bash runner
@@ -150,17 +149,26 @@ RUN ln -s /opt/R/4.4.0/bin/R /usr/local/bin/R && \
 # Copy R packages from builder
 COPY --from=builder --chown=runner:runner /home/runner/build/r_libs /home/runner/build/r_libs
 
-# Copy rapache module (same path as builder since same distro family)
-COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib64/httpd/modules/mod_R.so
+# Copy rapache module (Debian uses different Apache module path)
+COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib/apache2/modules/mod_R.so
 
-# Copy nlopt (not in UBI repos, keep from builder)
+# Copy libapreq2 (not available in Debian repos)
+COPY --from=builder /lib64/libapreq2.so.3* /usr/lib/
+
+# Copy ICU libs from builder (R compiled against CentOS ICU 67, Debian has 72)
+COPY --from=builder /lib64/libicuuc.so.67* /usr/lib/
+COPY --from=builder /lib64/libicui18n.so.67* /usr/lib/
+COPY --from=builder /lib64/libicudata.so.67* /usr/lib/
+
+# Copy and relocate nlopt to standard library path
 COPY --from=builder /nlopt-2.7.1/libnlopt.so.0.11.1 /usr/local/lib/
 RUN ln -s /usr/local/lib/libnlopt.so.0.11.1 /usr/local/lib/libnlopt.so.0 && \
     ln -s /usr/local/lib/libnlopt.so.0 /usr/local/lib/libnlopt.so && \
     ldconfig
 
 # Environment setup
-ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+ARG TARGETARCH
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH:-amd64}
 ENV R_VERSION=4.4.0
 ENV R_LIBS=/home/runner/build/r_libs
 ENV ACAS_HOME=/home/runner/build

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -1,33 +1,49 @@
 # syntax=docker/dockerfile:1
 
 # =============================================================================
+# Build configuration
+# =============================================================================
+ARG R_VERSION=4.4.0
+ARG JAVA_VERSION=1.8.0
+ARG NLOPT_VERSION=2.7.1
+ARG RAPACHE_VERSION=v1.2.11
+
+# =============================================================================
 # STAGE 1: Builder (CentOS Stream 9)
 # Compiles R, rapache, nlopt from source and installs R packages
 # =============================================================================
 FROM quay.io/centos/centos:stream9 AS builder
 
-# R-Java
-ENV JAVA_VERSION=1.8.0
+ARG R_VERSION
+ARG JAVA_VERSION
+ARG NLOPT_VERSION
+ARG RAPACHE_VERSION
+
+# Java environment for rJava compilation
 ENV JAVA_HOME=/usr/lib/jvm/java
 RUN echo "$JAVA_HOME/jre/lib/$(arch)/server/" > /etc/ld.so.conf.d/rApache_rJava.conf && \
-    export LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/$(arch):$JAVA_HOME/jre/lib/$(arch)/server/ && \
-    /sbin/ldconfig
+    ldconfig
 
-# Use BuildKit cache mount to speed up repeated builds
+# Install build dependencies
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
-  echo "fastestmirror=1" >> /etc/dnf/dnf.conf && \
-  dnf update -y && \
-  dnf upgrade -y && \
-  dnf install -y epel-release && \
-  dnf config-manager --set-enabled crb && \
-  dnf module enable -y postgresql:15 && \
-  dnf install postgresql libpq libpq-devel -y && \
-  dnf install -y rpm-build which make wget tar httpd-devel libapreq2-devel libcurl-devel openssl-devel libpng-devel java-1.8.0-openjdk java-1.8.0-openjdk-devel curl-devel libxml2-devel llvm-devel llvm-toolset cmake initscripts && \
-  dnf builddep -y R-devel && \
-  dnf install -y MTA mod_ssl /usr/sbin/semanage && \
-  dnf clean all
+    echo "fastestmirror=1" >> /etc/dnf/dnf.conf && \
+    dnf update -y && dnf upgrade -y && \
+    dnf install -y epel-release && \
+    dnf config-manager --set-enabled crb && \
+    dnf module enable -y postgresql:15 && \
+    dnf install -y \
+        postgresql libpq libpq-devel \
+        which make wget tar cmake \
+        httpd-devel libapreq2-devel \
+        libcurl-devel openssl-devel libpng-devel curl-devel libxml2-devel \
+        llvm-devel llvm-toolset \
+        java-${JAVA_VERSION}-openjdk java-${JAVA_VERSION}-openjdk-devel \
+        MTA mod_ssl /usr/sbin/semanage && \
+    dnf builddep -y R-devel && \
+    dnf clean all
 
-ENV R_VERSION=4.4.0
+# Compile R from source
+ENV R_VERSION=${R_VERSION}
 RUN curl -O https://cran.rstudio.com/src/base/R-4/R-${R_VERSION}.tar.gz && \
     tar -xzvf R-${R_VERSION}.tar.gz && \
     cd R-${R_VERSION} && \
@@ -37,163 +53,109 @@ RUN curl -O https://cran.rstudio.com/src/base/R-4/R-${R_VERSION}.tar.gz && \
         --enable-R-shlib \
         --with-blas \
         --with-lapack && \
-    make && \
-    make install
+    make && make install && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript && \
+    R CMD javareconf
 
-RUN ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R
-RUN ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript
-
-RUN R CMD javareconf
-
-# Install renv globally for package management (before COPY to optimize layer caching)
+# Install renv for R package management
 RUN Rscript -e "install.packages('renv', repos = 'https://cloud.r-project.org/')"
 
-RUN \
-  mkdir -p ~/rpmbuild/SOURCES && \
-  mkdir -p ~/rpmbuild/SPECS
+# Compile rapache (Apache R module)
+# See https://github.com/jeffreyhorner/rapache/tags for releases
+ENV RAPACHE_VERSION=${RAPACHE_VERSION}
+RUN cd ~ && \
+    wget https://github.com/jeffreyhorner/rapache/archive/refs/tags/${RAPACHE_VERSION}.tar.gz \
+        -O rapache-${RAPACHE_VERSION}.tar.gz && \
+    tar xzvf rapache-${RAPACHE_VERSION}.tar.gz && \
+    cd rapache-${RAPACHE_VERSION#v} && \
+    ./configure --with-R=/usr/local/bin/R --with-apreq2-config=/usr/bin/apreq2-config && \
+    make && make install
 
-# Pin rapache to a specific release tag for reproducible builds
-# Check https://github.com/jeffreyhorner/rapache/tags for latest releases
-ENV RAPACHE_VERSION=v1.2.11
-RUN \
-  cd ~ && \
-  wget https://github.com/jeffreyhorner/rapache/archive/refs/tags/$RAPACHE_VERSION.tar.gz -O rapache-$RAPACHE_VERSION.tar.gz && \
-  tar xzvf rapache-$RAPACHE_VERSION.tar.gz && \
-  cd rapache-${RAPACHE_VERSION#v} && \
-  ./configure \
-    --with-R=/usr/local/bin/R\
-    --with-apreq2-config=/usr/bin/apreq2-config && \
-  make && \
-  make install
-
-ENV NLOPT_VERSION=2.7.1
+# Compile nlopt (optimization library for nloptr R package)
+ENV NLOPT_VERSION=${NLOPT_VERSION}
 RUN wget https://github.com/stevengj/nlopt/archive/v${NLOPT_VERSION}.tar.gz && \
     tar -xzvf v${NLOPT_VERSION}.tar.gz && \
     cd nlopt-${NLOPT_VERSION} && \
-    cmake . && make && make install
+    cmake . && make && make install && \
+    ldconfig
 ENV LD_LIBRARY_PATH=/nlopt-${NLOPT_VERSION}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-# Run ldconfig to update the shared library cache
-RUN ldconfig
 
-RUN	useradd -u 1000 -ms /bin/bash runner
+# Setup build user and directories
 ENV ACAS_HOME=/home/runner/build
-RUN echo $ACAS_HOME && mkdir $ACAS_HOME
+ENV R_LIBS=${ACAS_HOME}/r_libs
+RUN useradd -u 1000 -ms /bin/bash runner && \
+    mkdir -p ${R_LIBS} && \
+    chown -R runner:runner ${ACAS_HOME}
 
-WORKDIR $ACAS_HOME
+WORKDIR ${ACAS_HOME}
+COPY --chown=runner:runner DESCRIPTION R/installation.R renv.lock ${ACAS_HOME}/
 
-ENV R_LIBS=$ACAS_HOME/r_libs
-RUN mkdir $ACAS_HOME/r_libs
-
-COPY	DESCRIPTION $ACAS_HOME
-COPY	R/installation.R $ACAS_HOME
-# renv.lock pins exact package versions for reproducible builds
-COPY	renv.lock $ACAS_HOME
-RUN chown -R runner:runner $ACAS_HOME
-
+# Install R packages using renv (versions pinned in renv.lock)
 USER runner
-# R package installation using renv for reproducibility:
-# - Versions pinned in renv.lock (see README for update instructions)
-# - Cache mount stores compiled packages to speed up rebuilds
 ARG TARGETARCH
 RUN --mount=type=cache,target=/home/runner/.cache/R/renv,uid=1000,id=renv-$TARGETARCH \
     Rscript -e " \
       options(repos = c(CRAN = 'https://cloud.r-project.org')); \
       lib <- Sys.getenv('R_LIBS'); \
-      # Pre-install packages with LinkingTo deps (renv doesn't order these correctly) \
       renv::restore(packages = c('digest', 'testthat', 'fansi'), library = lib, prompt = FALSE); \
       renv::restore(packages = c('rematch2', 'tibble'), library = lib, prompt = FALSE); \
       renv::restore(library = lib, prompt = FALSE)"
 
 # =============================================================================
 # STAGE 2: Runtime (UBI9 Minimal)
-# Minimal RHEL-based runtime - same distro family as builder for compatibility
+# Minimal RHEL-based runtime for binary compatibility with builder
 # =============================================================================
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
 
-# Runtime dependencies (RHEL packages via microdnf)
-# Note: libcurl-minimal is pre-installed and conflicts with libcurl
+ARG R_VERSION
+ARG JAVA_VERSION
+ARG NLOPT_VERSION
+
+# Runtime dependencies
+# Note: libcurl-minimal pre-installed, conflicts with full libcurl
 RUN microdnf install -y \
-    # Apache for rapache (libapreq2 copied from builder)
     httpd \
-    # Basic utilities needed by R and acas.sh
-    which \
-    initscripts \
-    # Java 1.8 for rJava (same as builder)
-    java-1.8.0-openjdk-headless \
-    # PostgreSQL client libs (for RPostgreSQL)
+    which initscripts \
+    java-${JAVA_VERSION}-openjdk-headless \
     libpq \
-    # R runtime dependencies (from ldd analysis)
-    pcre2 \
-    xz-libs \
-    bzip2-libs \
-    zlib \
-    libicu \
-    libgomp \
-    libgfortran \
-    readline \
-    libxml2 \
-    libpng \
-    openssl-libs \
-    libtirpc \
-    # Graphics libraries for R plots (Cairo backend)
-    libtiff \
-    libjpeg-turbo \
-    cairo \
-    pango \
-    libSM \
-    libXt \
-    # Fonts (for R plots)
-    fontconfig \
-    dejavu-sans-fonts \
+    pcre2 xz-libs bzip2-libs zlib libicu libgomp libgfortran \
+    readline libxml2 libpng openssl-libs libtirpc \
+    libtiff libjpeg-turbo cairo pango libSM libXt \
+    fontconfig dejavu-sans-fonts \
     && microdnf clean all
 
-# Create runner user (match UID from builder)
+# Setup user and copy R installation
 RUN useradd -u 1000 -ms /bin/bash runner
-
-# Copy R installation from builder
-COPY --from=builder /opt/R/4.4.0 /opt/R/4.4.0
-RUN ln -s /opt/R/4.4.0/bin/R /usr/local/bin/R && \
-    ln -s /opt/R/4.4.0/bin/Rscript /usr/local/bin/Rscript && \
-    echo "/opt/R/4.4.0/lib/R/lib" > /etc/ld.so.conf.d/R.conf && \
-    # Find actual libjvm.so path (varies by arch: aarch64 vs amd64)
+COPY --from=builder /opt/R/${R_VERSION} /opt/R/${R_VERSION}
+RUN ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript && \
+    echo "/opt/R/${R_VERSION}/lib/R/lib" > /etc/ld.so.conf.d/R.conf && \
     dirname $(find /usr/lib/jvm -name libjvm.so 2>/dev/null | head -1) > /etc/ld.so.conf.d/java.conf && \
     ldconfig
 
-# Copy R packages from builder
+# Copy R packages and modules from builder
 COPY --from=builder --chown=runner:runner /home/runner/build/r_libs /home/runner/build/r_libs
-
-# Copy rapache module (same path as builder since same distro family)
 COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib64/httpd/modules/mod_R.so
 
-# Copy libs not in UBI repos
+# Copy libraries not available in UBI repos
 COPY --from=builder /lib64/libapreq2.so.3* /lib64/
 COPY --from=builder /lib64/libdeflate.so.0* /lib64/
-
-# Copy nlopt (not in UBI repos)
-COPY --from=builder /nlopt-2.7.1/libnlopt.so.0.11.1 /usr/local/lib/
-RUN ln -s /usr/local/lib/libnlopt.so.0.11.1 /usr/local/lib/libnlopt.so.0 && \
-    ln -s /usr/local/lib/libnlopt.so.0 /usr/local/lib/libnlopt.so && \
-    ldconfig
-
-# Environment setup
-ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
-ENV R_VERSION=4.4.0
-ENV R_LIBS=/home/runner/build/r_libs
-ENV ACAS_HOME=/home/runner/build
-ENV LD_LIBRARY_PATH=/opt/R/${R_VERSION}/lib/R/lib:/usr/local/lib:${JAVA_HOME}/lib/server
-
-# Ensure shared library cache is updated
+COPY --from=builder /nlopt-${NLOPT_VERSION}/libnlopt.so.0* /usr/local/lib/
 RUN ldconfig
 
-# Setup working directory
-RUN mkdir -p $ACAS_HOME
-WORKDIR $ACAS_HOME
+# Environment configuration
+ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}-openjdk \
+    R_VERSION=${R_VERSION} \
+    R_LIBS=/home/runner/build/r_libs \
+    ACAS_HOME=/home/runner/build \
+    LD_LIBRARY_PATH=/opt/R/${R_VERSION}/lib/R/lib:/usr/local/lib
 
-# Configure R-Java integration
-RUN R CMD javareconf
+# Final setup
+WORKDIR ${ACAS_HOME}
+RUN mkdir -p ${ACAS_HOME} && \
+    R CMD javareconf && \
+    chown -R runner:runner /home/runner
 
-# Switch to non-root user
-RUN chown -R runner:runner /home/runner
 USER runner
-
 CMD ["bin/acas.sh", "run", "rservices"]

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -135,6 +135,10 @@ RUN microdnf install -y \
     libpng \
     openssl-libs \
     libtirpc \
+    # Graphics libraries for R plots (Cairo backend)
+    libtiff \
+    libjpeg-turbo \
+    cairo \
     # Fonts (for R plots)
     fontconfig \
     dejavu-sans-fonts \

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -115,8 +115,9 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
 RUN microdnf install -y \
     # Apache for rapache (libapreq2 copied from builder)
     httpd \
-    # Basic utilities needed by R
+    # Basic utilities needed by R and acas.sh
     which \
+    initscripts \
     # Java 1.8 for rJava (same as builder)
     java-1.8.0-openjdk-headless \
     # PostgreSQL client libs (for RPostgreSQL)

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -158,4 +158,3 @@ RUN mkdir -p ${ACAS_HOME} && \
     chown -R runner:runner /home/runner
 
 USER runner
-CMD ["bin/acas.sh", "run", "rservices"]

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -112,9 +112,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
 
 # Runtime dependencies (RHEL packages via microdnf)
 RUN microdnf install -y \
-    # Apache + libapreq2 for rapache
+    # Apache for rapache (libapreq2 copied from builder)
     httpd \
-    libapreq2 \
     # Java 1.8 for rJava (same as builder)
     java-1.8.0-openjdk-headless \
     # PostgreSQL client libs (for RPostgreSQL)
@@ -153,7 +152,10 @@ COPY --from=builder --chown=runner:runner /home/runner/build/r_libs /home/runner
 # Copy rapache module (same path as builder since same distro family)
 COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib64/httpd/modules/mod_R.so
 
-# Copy nlopt (not in UBI repos, keep from builder)
+# Copy libapreq2 (not in UBI repos)
+COPY --from=builder /lib64/libapreq2.so.3* /lib64/
+
+# Copy nlopt (not in UBI repos)
 COPY --from=builder /nlopt-2.7.1/libnlopt.so.0.11.1 /usr/local/lib/
 RUN ln -s /usr/local/lib/libnlopt.so.0.11.1 /usr/local/lib/libnlopt.so.0 && \
     ln -s /usr/local/lib/libnlopt.so.0 /usr/local/lib/libnlopt.so && \

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -120,7 +120,6 @@ RUN microdnf install -y \
     libpq \
     # R runtime dependencies (from ldd analysis)
     pcre2 \
-    libdeflate \
     xz-libs \
     bzip2-libs \
     zlib \
@@ -152,8 +151,9 @@ COPY --from=builder --chown=runner:runner /home/runner/build/r_libs /home/runner
 # Copy rapache module (same path as builder since same distro family)
 COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib64/httpd/modules/mod_R.so
 
-# Copy libapreq2 (not in UBI repos)
+# Copy libs not in UBI repos
 COPY --from=builder /lib64/libapreq2.so.3* /lib64/
+COPY --from=builder /lib64/libdeflate.so.0* /lib64/
 
 # Copy nlopt (not in UBI repos)
 COPY --from=builder /nlopt-2.7.1/libnlopt.so.0.11.1 /usr/local/lib/

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -120,6 +120,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # PostgreSQL client libs (for RPostgreSQL)
     libpq5 \
     # R runtime dependencies (from ldd analysis)
+    libtirpc3 \
     libpcre2-8-0 \
     libdeflate0 \
     liblzma5 \

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -148,7 +148,8 @@ COPY --from=builder /opt/R/4.4.0 /opt/R/4.4.0
 RUN ln -s /opt/R/4.4.0/bin/R /usr/local/bin/R && \
     ln -s /opt/R/4.4.0/bin/Rscript /usr/local/bin/Rscript && \
     echo "/opt/R/4.4.0/lib/R/lib" > /etc/ld.so.conf.d/R.conf && \
-    echo "/usr/lib/jvm/jre-1.8.0-openjdk/lib/server" > /etc/ld.so.conf.d/java.conf && \
+    # Find actual libjvm.so path (varies by arch: aarch64 vs amd64)
+    dirname $(find /usr/lib/jvm -name libjvm.so 2>/dev/null | head -1) > /etc/ld.so.conf.d/java.conf && \
     ldconfig
 
 # Copy R packages from builder

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -139,6 +139,9 @@ RUN microdnf install -y \
     libtiff \
     libjpeg-turbo \
     cairo \
+    pango \
+    libSM \
+    libXt \
     # Fonts (for R plots)
     fontconfig \
     dejavu-sans-fonts \

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     dnf module enable -y postgresql:15 && \
     dnf install -y \
         postgresql libpq libpq-devel \
-        which make wget tar cmake \
+        which make wget tar cmake redhat-rpm-config \
         httpd-devel libapreq2-devel \
         libcurl-devel openssl-devel libpng-devel curl-devel libxml2-devel \
         llvm-devel llvm-toolset \

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -1,5 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM quay.io/centos/centos:stream9
+
+# =============================================================================
+# STAGE 1: Builder (CentOS Stream 9)
+# Compiles R, rapache, nlopt from source and installs R packages
+# =============================================================================
+FROM quay.io/centos/centos:stream9 AS builder
 
 # R-Java
 ENV JAVA_VERSION=1.8.0
@@ -98,5 +103,81 @@ RUN --mount=type=cache,target=/home/runner/.cache/R/renv,uid=1000,id=renv-$TARGE
       renv::restore(packages = c('digest', 'testthat', 'fansi'), library = lib, prompt = FALSE); \
       renv::restore(packages = c('rematch2', 'tibble'), library = lib, prompt = FALSE); \
       renv::restore(library = lib, prompt = FALSE)"
+
+# =============================================================================
+# STAGE 2: Runtime (Debian Slim)
+# Minimal runtime with only what's needed to run R/rapache
+# =============================================================================
+FROM debian:bookworm-slim AS runtime
+
+# Runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Apache + mod_apreq2 for rapache
+    apache2 \
+    libapache2-mod-apreq2 \
+    # Java 8 for rJava
+    openjdk-8-jre-headless \
+    # PostgreSQL client libs (for RPostgreSQL)
+    libpq5 \
+    # R runtime dependencies (from ldd analysis)
+    libpcre2-8-0 \
+    libdeflate0 \
+    liblzma5 \
+    libbz2-1.0 \
+    zlib1g \
+    libicu72 \
+    libgomp1 \
+    libgfortran5 \
+    libreadline8 \
+    libcurl4 \
+    libxml2 \
+    libpng16-16 \
+    libssl3 \
+    # Fonts (for R plots)
+    fontconfig \
+    fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create runner user (match UID from builder)
+RUN useradd -u 1000 -ms /bin/bash runner
+
+# Copy R installation from builder
+COPY --from=builder /opt/R/4.4.0 /opt/R/4.4.0
+RUN ln -s /opt/R/4.4.0/bin/R /usr/local/bin/R && \
+    ln -s /opt/R/4.4.0/bin/Rscript /usr/local/bin/Rscript
+
+# Copy R packages from builder
+COPY --from=builder --chown=runner:runner /home/runner/build/r_libs /home/runner/build/r_libs
+
+# Copy rapache module (Debian uses different Apache module path)
+COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib/apache2/modules/mod_R.so
+
+# Copy and relocate nlopt to standard library path
+COPY --from=builder /nlopt-2.7.1/libnlopt.so.0.11.1 /usr/local/lib/
+RUN ln -s /usr/local/lib/libnlopt.so.0.11.1 /usr/local/lib/libnlopt.so.0 && \
+    ln -s /usr/local/lib/libnlopt.so.0 /usr/local/lib/libnlopt.so && \
+    ldconfig
+
+# Environment setup
+ARG TARGETARCH
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-${TARGETARCH:-amd64}
+ENV R_VERSION=4.4.0
+ENV R_LIBS=/home/runner/build/r_libs
+ENV ACAS_HOME=/home/runner/build
+ENV LD_LIBRARY_PATH=/opt/R/${R_VERSION}/lib/R/lib:/usr/local/lib:${JAVA_HOME}/lib/server
+
+# Ensure shared library cache is updated
+RUN ldconfig
+
+# Setup working directory
+RUN mkdir -p $ACAS_HOME
+WORKDIR $ACAS_HOME
+
+# Configure R-Java integration
+RUN R CMD javareconf
+
+# Switch to non-root user
+RUN chown -R runner:runner /home/runner
+USER runner
 
 CMD ["bin/acas.sh", "run", "rservices"]

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -112,9 +112,9 @@ FROM debian:bookworm-slim AS runtime
 
 # Runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    # Apache for rapache (mod_apreq2 libs copied from builder)
+    # Apache for rapache
     apache2 \
-    libapreq2-3 \
+    libaprutil1 \
     # Java 17 for rJava (Java 8 not in Debian Bookworm)
     openjdk-17-jre-headless \
     # PostgreSQL client libs (for RPostgreSQL)
@@ -151,6 +151,9 @@ COPY --from=builder --chown=runner:runner /home/runner/build/r_libs /home/runner
 
 # Copy rapache module (Debian uses different Apache module path)
 COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib/apache2/modules/mod_R.so
+
+# Copy libapreq2 (not available in Debian repos)
+COPY --from=builder /lib64/libapreq2.so.3* /usr/lib/
 
 # Copy and relocate nlopt to standard library path
 COPY --from=builder /nlopt-2.7.1/libnlopt.so.0.11.1 /usr/local/lib/

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -111,6 +111,7 @@ RUN --mount=type=cache,target=/home/runner/.cache/R/renv,uid=1000,id=renv-$TARGE
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
 
 # Runtime dependencies (RHEL packages via microdnf)
+# Note: libcurl-minimal is pre-installed and conflicts with libcurl
 RUN microdnf install -y \
     # Apache for rapache (libapreq2 copied from builder)
     httpd \
@@ -127,7 +128,6 @@ RUN microdnf install -y \
     libgomp \
     libgfortran \
     readline \
-    libcurl \
     libxml2 \
     libpng \
     openssl-libs \

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -148,6 +148,7 @@ COPY --from=builder /opt/R/4.4.0 /opt/R/4.4.0
 RUN ln -s /opt/R/4.4.0/bin/R /usr/local/bin/R && \
     ln -s /opt/R/4.4.0/bin/Rscript /usr/local/bin/Rscript && \
     echo "/opt/R/4.4.0/lib/R/lib" > /etc/ld.so.conf.d/R.conf && \
+    echo "/usr/lib/jvm/jre-1.8.0-openjdk/lib/server" > /etc/ld.so.conf.d/java.conf && \
     ldconfig
 
 # Copy R packages from builder

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -71,7 +71,7 @@ RUN wget https://github.com/stevengj/nlopt/archive/v${NLOPT_VERSION}.tar.gz && \
     tar -xzvf v${NLOPT_VERSION}.tar.gz && \
     cd nlopt-${NLOPT_VERSION} && \
     cmake . && make && make install
-ENV LD_LIBRARY_PATH=/nlopt-${NLOPT_VERSION}:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/nlopt-${NLOPT_VERSION}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 # Run ldconfig to update the shared library cache
 RUN ldconfig
 
@@ -112,11 +112,11 @@ FROM debian:bookworm-slim AS runtime
 
 # Runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    # Apache + mod_apreq2 for rapache
+    # Apache for rapache (mod_apreq2 libs copied from builder)
     apache2 \
-    libapache2-mod-apreq2 \
-    # Java 8 for rJava
-    openjdk-8-jre-headless \
+    libapreq2-3 \
+    # Java 17 for rJava (Java 8 not in Debian Bookworm)
+    openjdk-17-jre-headless \
     # PostgreSQL client libs (for RPostgreSQL)
     libpq5 \
     # R runtime dependencies (from ldd analysis)
@@ -160,7 +160,7 @@ RUN ln -s /usr/local/lib/libnlopt.so.0.11.1 /usr/local/lib/libnlopt.so.0 && \
 
 # Environment setup
 ARG TARGETARCH
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-${TARGETARCH:-amd64}
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH:-amd64}
 ENV R_VERSION=4.4.0
 ENV R_LIBS=/home/runner/build/r_libs
 ENV ACAS_HOME=/home/runner/build

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -146,7 +146,9 @@ RUN useradd -u 1000 -ms /bin/bash runner
 # Copy R installation from builder
 COPY --from=builder /opt/R/4.4.0 /opt/R/4.4.0
 RUN ln -s /opt/R/4.4.0/bin/R /usr/local/bin/R && \
-    ln -s /opt/R/4.4.0/bin/Rscript /usr/local/bin/Rscript
+    ln -s /opt/R/4.4.0/bin/Rscript /usr/local/bin/Rscript && \
+    echo "/opt/R/4.4.0/lib/R/lib" > /etc/ld.so.conf.d/R.conf && \
+    ldconfig
 
 # Copy R packages from builder
 COPY --from=builder --chown=runner:runner /home/runner/build/r_libs /home/runner/build/r_libs

--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -126,7 +126,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     liblzma5 \
     libbz2-1.0 \
     zlib1g \
-    libicu72 \
     libgomp1 \
     libgfortran5 \
     libreadline8 \
@@ -155,6 +154,11 @@ COPY --from=builder /usr/lib64/httpd/modules/mod_R.so /usr/lib/apache2/modules/m
 
 # Copy libapreq2 (not available in Debian repos)
 COPY --from=builder /lib64/libapreq2.so.3* /usr/lib/
+
+# Copy ICU libs from builder (R compiled against CentOS ICU 67, Debian has 72)
+COPY --from=builder /lib64/libicuuc.so.67* /usr/lib/
+COPY --from=builder /lib64/libicui18n.so.67* /usr/lib/
+COPY --from=builder /lib64/libicudata.so.67* /usr/lib/
 
 # Copy and relocate nlopt to standard library path
 COPY --from=builder /nlopt-2.7.1/libnlopt.so.0.11.1 /usr/local/lib/


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Previous PR #110 stabilized regular `acas-r-repo` base image builds with the goal of fixing CVEs. This PR extends that work to switch to a slimmer runtime base image. The goals here are to reduce CVE surface and also reduce the final image size.
- Build/compile stage still based on `quay.io/centos/centos:stream9`. Minor cleanup / refactoring for readability
- New stage based on `registry.access.redhat.com/ubi9/ubi-minimal` that installs only runtime dependencies & compiled libraries
- Final image size reduced from 4G to 1G

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
- All acasclient CI tests pass
- Confirmed httpd is still updated to `2.4.62` within the image
- Manually tested Dose Response module, confirmed Goodness of Fit histograms and curve images all work as expected.