### PR TITLE
ACAS-973: Update ld library path for amd64 images

### DIFF
--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -79,7 +79,7 @@ RUN wget https://github.com/stevengj/nlopt/archive/v${NLOPT_VERSION}.tar.gz && \
     cd nlopt-${NLOPT_VERSION} && \
     cmake . && make && make install && \
     ldconfig
-ENV LD_LIBRARY_PATH=/nlopt-${NLOPT_VERSION}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/nlopt-${NLOPT_VERSION}
 
 # Setup build user and directories
 ENV ACAS_HOME=/home/runner/build
@@ -130,7 +130,7 @@ RUN useradd -u 1000 -ms /bin/bash runner
 COPY --from=builder /opt/R/${R_VERSION} /opt/R/${R_VERSION}
 RUN ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript && \
-    echo "/opt/R/${R_VERSION}/lib/R/lib" > /etc/ld.so.conf.d/R.conf && \
+    dirname $(find /opt/R/${R_VERSION} -name "libR.so" 2>/dev/null | head -1) > /etc/ld.so.conf.d/R.conf && \
     dirname $(find /usr/lib/jvm -name libjvm.so 2>/dev/null | head -1) > /etc/ld.so.conf.d/java.conf && \
     ldconfig
 
@@ -149,7 +149,7 @@ ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}-openjdk \
     R_VERSION=${R_VERSION} \
     R_LIBS=/home/runner/build/r_libs \
     ACAS_HOME=/home/runner/build \
-    LD_LIBRARY_PATH=/opt/R/${R_VERSION}/lib/R/lib:/usr/local/lib
+    LD_LIBRARY_PATH=/opt/R/${R_VERSION}/lib/R/lib:/opt/R/${R_VERSION}/lib64/R/lib:/usr/local/lib
 
 # Final setup
 WORKDIR ${ACAS_HOME}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On x86_64 (amd64), R installs its libraries into lib64/R/lib rather than lib/R/lib — a multilib convention on RPM-based Linux where lib64 holds native 64-bit libraries. The slimmer multi-stage image introduced in #112 hardcoded lib/R/lib in the ldconfig config, which worked on arm64 (Apple Silicon dev machines) but caused rapache to fail at startup on amd64 CI images with:

```
Error: package or namespace load failed for 'racas' in dyn.load(file, DLLpath = DLLpath, ...):
  unable to load shared object '.../stats/libs/stats.so':
  libRlapack.so: cannot open shared object file: No such file or directory
```

Changes:

- Detect the R library path dynamically using find -name "libR.so" (same pattern already used for libjvm.so) instead of hardcoding lib/R/lib
 - Add lib64/R/lib to LD_LIBRARY_PATH as a belt-and-suspenders fallback
 - Simplify an unused conditional variable append in the builder stage (${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} was always empty since LD_LIBRARY_PATH had no prior definition) which was producing this warning `- UndefinedVar: Usage of undefined variable '$LD_LIBRARY_PATH' (line 82)`

## How Has This Been Tested?
### This shows the initial problem:

```
docker run --rm --platform linux/amd64 \
  us-central1-docker.pkg.dev/livedesign-images/master/rservices:10888 \
  ldconfig -p | grep libRlapack
```

> no output (this is a problem)


or equivalently on acas-r-repo:master currently:

```
docker run --rm --platform linux/amd64 \
  mcneilco/acas-r-repo:master \
  ldconfig -p | grep libRlapack
```

> no output either

On arm:

```
docker run --rm --platform linux/arm64 \
  mcneilco/acas-r-repo:master \
  ldconfig -p | grep libRlapack
```


> libRlapack.so (libc6,AArch64) => /opt/R/4.4.0/lib/R/lib/libRlapack.so

### This shows the fix

```
docker buildx build --platform linux/amd64 -t acas-r-repo-test -f Dockerfile.repo . --load
```

```
docker run --rm --platform linux/amd64 \
  acas-r-repo-test \
  ldconfig -p | grep libRlapack
```

Now shows the correct output

```
        libRlapack.so (libc6,x86-64) => /opt/R/4.4.0/lib64/R/lib/libRlapack.so
```
