### PR TITLE
ACAS-980: Fix renv::restore circular dependency by removing DESCRIPTION

### DIFF
--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -89,7 +89,7 @@ RUN useradd -u 1000 -ms /bin/bash runner && \
     chown -R runner:runner ${ACAS_HOME}
 
 WORKDIR ${ACAS_HOME}
-COPY --chown=runner:runner DESCRIPTION R/installation.R renv.lock ${ACAS_HOME}/
+COPY --chown=runner:runner R/installation.R renv.lock ${ACAS_HOME}/
 
 # Install R packages using renv (versions pinned in renv.lock)
 USER runner


### PR DESCRIPTION
### Problem

  The "Rebuild Base Image" scheduled CI builds have been failing since 2026-04-26. Every
  scheduled build (fresh runner, no layer cache) failed with 37 of 93 R packages never
  attempted by `renv::restore` — including viridisLite, ggplot2, scales, RCurl, and rJava.

  ### Root cause

  `DESCRIPTION` was included in the `COPY` step of the `Dockerfile.repo` builder stage.
  When `renv::restore` runs in a directory containing a `DESCRIPTION` file, it enters
  project mode and incorporates the package's `Imports` into its dependency scheduling
  graph. This created a circular dependency:

  - racas `Imports` → ggplot2
  - ggplot2 `Imports` → scales
  - scales `Imports` → viridisLite
  - viridisLite lockfile `Suggests` → ggplot2

  renv could not schedule viridisLite without ggplot2, could not schedule ggplot2 without
  scales, could not schedule scales without viridisLite. All 37 packages in that dependency
  wave were silently skipped.

**Why CI appeared healthy after April 22:** The last successful build cached the renv
  layer in the registry. Subsequent push-triggered builds reused that cached layer and
  never re-ran `renv::restore`, so the deadlock was never triggered. Only the weekly
  scheduled builds — which always build from scratch — exposed the failure.

  ### Fix

  Remove `DESCRIPTION` from the `COPY` command in the builder stage. `renv::restore` reads
  exclusively from `renv.lock`, which already encodes all 93 package versions — `DESCRIPTION`
  is not needed at restore time and its presence actively interfered with dependency
  scheduling. 

  ### Verification

  Local `--no-cache` build on arm64 confirms all 93 packages install successfully:

  Successfully installed 93 packages in 160 seconds.