### PR TITLE
ACAS-988: Pin rservices runtime base to ubi9/ubi-minimal:9.8

### DIFF
--- a/Dockerfile.repo
+++ b/Dockerfile.repo
@@ -106,7 +106,7 @@ RUN --mount=type=cache,target=/home/runner/.cache/R/renv,uid=1000,id=renv-$TARGE
 # STAGE 2: Runtime (UBI9 Minimal)
 # Minimal RHEL-based runtime for binary compatibility with builder
 # =============================================================================
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8 AS runtime
 
 ARG R_VERSION
 ARG JAVA_VERSION


### PR DESCRIPTION
## Problem
The `Dockerfile.repo` runtime stage used `registry.access.redhat.com/ubi9/ubi-minimal` **untagged** (implicit `:latest`), violating the [container image security baselines](https://schrodinger.atlassian.net/wiki/spaces/LDE/pages/1940160531) requirement that base images be pinned to a specific version (never `:latest`/rolling).

## Change
Pin the runtime base to `ubi9/ubi-minimal:9.8` — the current GA minor, which is exactly what `:latest` already resolved to (verified: `:latest` and `:9.8` share digest `sha256:ae09ecc3…`). So this is an explicit pin, not a real version change. ubi-minimal is already an accepted minimal base.

The builder stage (`quay.io/centos/centos:stream9`) is a discarded build stage and CentOS Stream publishes no patch/semver tags, so it is left as-is.

Part of ACAS-988.

## Testing
passes acasclient tests.